### PR TITLE
Add producer errors, and convert delivery report error from string to code for richer errors

### DIFF
--- a/lib/kafkajs/_common.js
+++ b/lib/kafkajs/_common.js
@@ -1,5 +1,4 @@
 const error = require("./_error");
-const LibrdKafkaError = require('../error');
 
 /**
  * @function kafkaJSToRdKafkaConfig()
@@ -47,7 +46,13 @@ async function kafkaJSToRdKafkaConfig(config) {
   return { globalConfig, topicConfig };
 }
 
+/**
+ * Converts a topicPartitionOffset from KafkaJS to a format that can be used by node-rdkafka.
+ * @param {import("../../types/kafkajs").TopicPartitionOffset} tpo
+ * @returns {{topic: string, partition: number, offset: number}}
+ */
 function topicPartitionOffsetToRdKafka(tpo) {
+  // TODO: do we need some checks for negative offsets and stuff? Or 'named' offsets?
   return {
     topic: tpo.topic,
     partition: tpo.partition,
@@ -57,8 +62,8 @@ function topicPartitionOffsetToRdKafka(tpo) {
 
 /**
  * Convert a librdkafka error from node-rdkafka into a KafkaJSError.
- * @param {LibrdKafkaError} librdKafkaError to convert from.
- * @returns KafkaJSError
+ * @param {import("../error")} librdKafkaError to convert from.
+ * @returns {error.KafkaJSError} the converted error.
  */
 function createKafkaJsErrorFromLibRdKafkaError(librdKafkaError) {
   const properties = {
@@ -72,34 +77,57 @@ function createKafkaJsErrorFromLibRdKafkaError(librdKafkaError) {
   let err = null;
 
   if (properties.code === error.ErrorCodes.ERR_OFFSET_OUT_OF_RANGE) {
-    err = new error.KafkaJSOffsetOutOfRange(e, properties);
+    err = new error.KafkaJSOffsetOutOfRange(librdKafkaError, properties);
   } else if (properties.code === error.ErrorCodes.ERR_REQUEST_TIMED_OUT) {
-    err = new error.KafkaJSRequestTimeoutError(e, properties);
+    err = new error.KafkaJSRequestTimeoutError(librdKafkaError, properties);
   } else if (properties.code === error.ErrorCodes.ERR__PARTIAL) {
-    err = new error.KafkaJSPartialMessageError(e, properties);
+    err = new error.KafkaJSPartialMessageError(librdKafkaError, properties);
   } else if (properties.code === error.ErrorCodes.ERR__AUTHENTICATION) {
-    err = new error.KafkaJSSASLAuthenticationError(e, properties);
+    err = new error.KafkaJSSASLAuthenticationError(librdKafkaError, properties);
   } else if (properties.code === error.ErrorCodes.ERR_GROUP_COORDINATOR_NOT_AVAILABLE) {
-    err = new error.KafkaJSGroupCoordinatorNotAvailableError(e, properties);
+    err = new error.KafkaJSGroupCoordinatorNotAvailableError(librdKafkaError, properties);
   } else if (properties.code === error.ErrorCodes.ERR__NOT_IMPLEMENTED) {
-    err = new error.KafkaJSNotImplemented(e, properties);
+    err = new error.KafkaJSNotImplemented(librdKafkaError, properties);
   } else if (properties.code === error.ErrorCodes.ERR__TIMED_OUT) {
-    err = new error.KafkaJSTimedOut(e, properties);
+    err = new error.KafkaJSTimedOut(librdKafkaError, properties);
   } else if (properties.code === error.ErrorCodes.ERR__ALL_BROKERS_DOWN) {
-    err = new error.KafkaJSNoBrokerAvailableError(e, properties);
+    err = new error.KafkaJSNoBrokerAvailableError(librdKafkaError, properties);
   } else if (properties.code === error.ErrorCodes.ERR__TRANSPORT) {
-    err = new error.KafkaJSConnectionError(e, properties);
+    err = new error.KafkaJSConnectionError(librdKafkaError, properties);
   } else if (properties.code > 0) { /* Indicates a non-local error */
-    err = new error.KafkaJSProtocolError(e, properties);
+    err = new error.KafkaJSProtocolError(librdKafkaError, properties);
   } else {
-    err = new error.KafkaJSError(e, properties);
+    err = new error.KafkaJSError(librdKafkaError, properties);
   }
 
+  console.log("Converted err = " + JSON.stringify(err, null, 2) + " librdkafka erro = " + JSON.stringify(librdKafkaError, null, 2));
   return err;
+}
+
+/**
+ * Converts KafkaJS headers to a format that can be used by node-rdkafka.
+ * @param {import("../../types/kafkajs").IHeaders|null} kafkaJSHeaders
+ * @returns {import("../../").MessageHeader[]|null} the converted headers.
+ */
+function convertToRdKafkaHeaders(kafkaJSHeaders) {
+  if (!kafkaJSHeaders) return null;
+
+  const headers = [];
+  for (const [key, value] of Object.entries(kafkaJSHeaders)) {
+    if (value.constructor === Array) {
+      for (const v of value) {
+        headers.push({ key, value: v });
+      }
+    } else {
+      headers.push({ key, value });
+    }
+  }
+  return headers;
 }
 
 module.exports = {
   kafkaJSToRdKafkaConfig,
   topicPartitionOffsetToRdKafka,
   createKafkaJsErrorFromLibRdKafkaError,
+  convertToRdKafkaHeaders,
 };

--- a/lib/kafkajs/_error.js
+++ b/lib/kafkajs/_error.js
@@ -30,7 +30,7 @@ class KafkaJSError extends Error {
 
         const errTypes = Object
             .keys(LibrdKafkaError.codes)
-            .filter(k => LibrdKafkaError.codes[k] === kjsErr.code);
+            .filter(k => LibrdKafkaError.codes[k] === this.code);
 
         if (errTypes.length !== 1) {
             this.type = LibrdKafkaError.codes.ERR_UNKNOWN;

--- a/lib/kafkajs/_kafka.js
+++ b/lib/kafkajs/_kafka.js
@@ -5,17 +5,29 @@ const error = require('./_error');
 class Kafka {
   #commonClientConfig = {};
 
+  /**
+   *
+   * @param {import("../../types/kafkajs").KafkaConfig} config
+   */
   constructor(config) {
     this.#commonClientConfig = config;
   }
 
+  /**
+   * Merge the producer/consumer specific configuration with the common configuration.
+   * @param {import("../../types/kafkajs").ProducerConfig|import("../../types/kafkajs").ConsumerConfig} config
+   * @returns
+   */
   #mergeConfiguration(config) {
     let baseConfig = Object.assign({}, this.#commonClientConfig);
     config = Object.assign({}, config);
 
+    // TODO: there's some confusion around this, as we currently allow
+    // rdKafka to be a function, but here, we don't seem to treat it as such.
+    // Correct this, so that only objects are allowed for `rdKafka`.
     let rdKafka = baseConfig.rdKafka;
     Object.assign(baseConfig, config);
-    if (rdKafka && config.rdKafka) {
+    if (typeof rdKafka === 'object' && typeof config.rdKafka === 'object') {
       baseConfig.rdKafka = {
         ...rdKafka,
         ...config.rdKafka,
@@ -24,10 +36,20 @@ class Kafka {
     return baseConfig;
   }
 
+  /**
+   * Creates a new producer.
+   * @param {import("../../types/kafkajs").ProducerConfig} config
+   * @returns {Producer}
+   */
   producer(config) {
     return new Producer(this.#mergeConfiguration(config));
   }
 
+  /**
+   * Creates a new consumer.
+   * @param {import("../../types/kafkajs").Consumer} config
+   * @returns {Consumer}
+   */
   consumer(config) {
     return new Consumer(this.#mergeConfiguration(config));
   }

--- a/lib/kafkajs/_producer.js
+++ b/lib/kafkajs/_producer.js
@@ -1,6 +1,8 @@
 const RdKafka = require('../rdkafka');
-const { kafkaJSToRdKafkaConfig, topicPartitionOffsetToRdKafka } = require('./_common');
+const { kafkaJSToRdKafkaConfig, topicPartitionOffsetToRdKafka, createKafkaJsErrorFromLibRdKafkaError, convertToRdKafkaHeaders } = require('./_common');
 const { Consumer } = require('./_consumer');
+const error = require('./_error');
+const { Buffer } = require('buffer');
 
 const ProducerState = Object.freeze({
   INIT: 0,
@@ -13,11 +15,40 @@ const ProducerState = Object.freeze({
 });
 
 class Producer {
-  #kJSConfig = null
+  /**
+   * kJSConfig is the kafkaJS config object.
+   * @type {import("../../types/kafkajs").ProducerConfig|null}
+   */
+  #kJSConfig = null;
+
+  /**
+   * rdKafkaConfig contains the config objects that will be passed to node-rdkafka.
+   * @type {{globalConfig: import("../../types/config").ProducerGlobalConfig, topicConfig: import("../../types/config").ProducerTopicConfig}|null}
+   */
   #rdKafkaConfig = null;
+
+  /**
+   * internalClient is the node-rdkafka client used by the API.
+   * @type {import("../rdkafka").Producer|null}
+   */
   #internalClient = null;
+
+  /**
+   * connectPromiseFunc is the set of promise functions used to resolve/reject the connect() promise.
+   * @type {{resolve: Function, reject: Function}|{}}
+   */
   #connectPromiseFunc = {};
+
+  /**
+   * state is the current state of the producer.
+   * @type {ProducerState}
+   */
   #state = ProducerState.INIT;
+
+  /**
+   * ongoingTransaction is true if there is an ongoing transaction.
+   * @type {boolean}
+   */
   #ongoingTransaction = false;
 
   /**
@@ -38,17 +69,22 @@ class Producer {
     const { globalConfig, topicConfig } = await kafkaJSToRdKafkaConfig(this.#kJSConfig);
     globalConfig.dr_cb = 'true';
 
-    if (this.#kJSConfig.hasOwnProperty('transactionalId')) {
+    if (Object.hasOwn(this.#kJSConfig, 'transactionalId')) {
       globalConfig['transactional.id'] = this.#kJSConfig.transactionalId;
     }
 
     return { globalConfig, topicConfig };
   }
 
+  /**
+   * Flattens a list of topics with partitions into a list of topic, partition, offset.
+   * @param {import("../../types/kafkajs").TopicOffsets[]} topics
+   * @returns {import("../../types/kafkajs").TopicPartitionOffset}
+   */
   #flattenTopicPartitionOffsets(topics) {
     return topics.flatMap(topic => {
       return topic.partitions.map(partition => {
-        return { partition: partition.partition, offset: partition.offset, topic: topic.topic };
+        return { partition: Number(partition.partition), offset: String(partition.offset), topic: String(topic.topic) };
       })
     })
   }
@@ -69,14 +105,45 @@ class Producer {
     this.#readyCb(null);
   }
 
-  async #readyCb(arg) {
-    if (this.#state !== ProducerState.CONNECTING && this.#state !== ProducerState.INITIALIZED_TRANSACTIONS) {
-      // I really don't know how to handle this now.
+  /**
+   * Processes a delivery report, converting it to the type that the promisified API uses.
+   * @param {import('../..').LibrdKafkaError} err
+   * @param {import('../..').DeliveryReport} report
+   */
+  #deliveryCallback(err, report) {
+    const opaque = report.opaque;
+    if (!opaque || (typeof opaque.resolve !== 'function' && typeof opaque.reject !== 'function')) {
+      // not sure how to handle this.
+      throw new error.KafkaJSError("Internal error: deliveryCallback called without opaque set properly", { code: error.ErrorCodes.ERR__STATE });
+    }
+
+    if (err) {
+      opaque.reject(createKafkaJsErrorFromLibRdKafkaError(err));
       return;
     }
 
-    let config = await this.#config();
-    if (config.hasOwnProperty('transactional.id') && this.#state !== ProducerState.INITIALIZED_TRANSACTIONS) {
+    delete report['opaque'];
+
+    const recordMetadata = {
+      topicName: report.topic,
+      partition: report.partition,
+      errorCode: 0,
+      baseOffset: report.offset,
+      logAppendTime: '-1',
+      logStartOffset: '0',
+    };
+
+    opaque.resolve(recordMetadata);
+  }
+
+  async #readyCb() {
+    if (this.#state !== ProducerState.CONNECTING && this.#state !== ProducerState.INITIALIZED_TRANSACTIONS) {
+      /* The connectPromiseFunc might not be set, so we throw such an error. It's a state error that we can't recover from. Probably a bug. */
+      throw new error.KafkaJSError(`Ready callback called in invalid state ${this.#state}`, { code: error.ErrorCodes.ERR__STATE });
+    }
+
+    const config = await this.#config();
+    if (Object.hasOwn(config, 'transactional.id') && this.#state !== ProducerState.INITIALIZED_TRANSACTIONS) {
       this.#state = ProducerState.INITIALIZING_TRANSACTIONS;
       this.#internalClient.initTransactions(5000 /* default: 5s */, this.#readyTransactions.bind(this));
       return;
@@ -84,8 +151,8 @@ class Producer {
 
     this.#state = ProducerState.CONNECTED;
 
-    // Start a loop to poll.
-    let pollInterval = setInterval(() => {
+    /* Start a loop to poll. the queues. */
+    const pollInterval = setInterval(() => {
       if (this.#state >= ProducerState.DISCONNECTING) {
         clearInterval(pollInterval);
         return;
@@ -93,51 +160,39 @@ class Producer {
       this.#internalClient.poll();
     }, 500);
 
-    this.#internalClient.on('delivery-report', function (err, report) {
-      //console.log('got delivery report', report, err);
-      const opaque = report.opaque;
-      if (!opaque) {
-        // not sure how to handle this.
-        return;
-      }
-      if (err) {
-        opaque.reject('err out');
-        return;
-      }
-      //console.log('delivery-report: ' + JSON.stringify(report));
-      delete report['opaque'];
-
-      const recordMetadata = {
-        topicName: report.topic,
-        partition: report.partition,
-        errorCode: 0,
-        baseOffset: report.offset,
-        logAppendTime: null,
-        logStartOffset: null,
-      }
-
-      opaque.resolve(recordMetadata);
-    });
+    this.#internalClient.on('delivery-report', this.#deliveryCallback.bind(this));
 
     // Resolve the promise.
     this.#connectPromiseFunc["resolve"]();
   }
 
-  #errorCb(args) {
-    console.log('error', args);
+  /**
+   * Callback for the event.error event, either fails the initial connect(), or logs the error.
+   * @param {Error} err
+   */
+  #errorCb(err) {
     if (this.#state === ProducerState.CONNECTING) {
-      this.#connectPromiseFunc["reject"](args);
+      this.#connectPromiseFunc["reject"](err);
     } else {
-      // do nothing for now.
+      /* TODO: we should log the error returned here, depending on the log level.
+       * Right now, we're just using console.err, but we should allow for a custom
+       * logger, or at least make a function in _common.js that handles consumer
+       * and producer. */
+      console.error(err);
     }
   }
 
+  /**
+   * Set up the client and connect to the bootstrap brokers.
+   * @returns {Promise<void>} Resolves when connection is complete, rejects on error.
+   */
   async connect() {
     if (this.#state !== ProducerState.INIT) {
-      return Promise.reject("Connect has already been called elsewhere.");
+      throw new error.KafkaJSError("Connect has already been called elsewhere.", { code: error.ErrorCodes.ERR__STATE });
     }
 
     this.#state = ProducerState.CONNECTING;
+
     const { globalConfig, topicConfig } = await this.#config();
     this.#internalClient = new RdKafka.Producer(globalConfig, topicConfig);
     this.#internalClient.on('ready', this.#readyCb.bind(this));
@@ -146,39 +201,50 @@ class Producer {
 
     return new Promise((resolve, reject) => {
       this.#connectPromiseFunc = { resolve, reject };
-      console.log("Connecting....");
       this.#internalClient.connect();
-      console.log("connect() called");
     });
   }
 
+  /**
+   * Disconnect from the brokers, clean-up and tear down the client.
+   * @returns {Promise<void>} Resolves when disconnect is complete, rejects on error.
+   */
   async disconnect() {
     if (this.#state >= ProducerState.DISCONNECTING) {
       return;
     }
+
     this.#state = ProducerState.DISCONNECTING;
     await new Promise((resolve, reject) => {
       const cb = (err) => {
-        err ? reject(err) : resolve();
+        if (err) {
+          reject(createKafkaJsErrorFromLibRdKafkaError(err));
+          return;
+        }
         this.#state = ProducerState.DISCONNECTED;
+        resolve();
       }
-      this.#internalClient.disconnect(5000, cb);
+      this.#internalClient.disconnect(5000 /* default timeout, 5000ms */, cb);
     });
   }
 
+  /**
+   * Start a transaction - can only be used with a transactional producer.
+   * @returns {Promise<Producer>} Resolves with the producer when the transaction is started.
+   */
   async transaction() {
     if (this.#state !== ProducerState.CONNECTED) {
-      return Promise.reject("Cannot start transaction without awaiting connect()");
+      throw new error.KafkaJSError("Cannot start transaction without awaiting connect()", { code: error.ErrorCodes.ERR__STATE });
     }
 
     if (this.#ongoingTransaction) {
-      return Promise.reject("Can only start one transaction at a time.");
+      throw new error.KafkaJSError("Can only start one transaction at a time.", { code: error.ErrorCodes.ERR__STATE });
     }
 
     return new Promise((resolve, reject) => {
       this.#internalClient.beginTransaction((err) => {
         if (err) {
-          reject(err);
+          reject(createKafkaJsErrorFromLibRdKafkaError(err));
           return;
         }
         this.#ongoingTransaction = true;
@@ -191,20 +257,24 @@ class Producer {
     });
   }
 
+  /**
+   * Commit the current transaction.
+   * @returns {Promise<void>} Resolves when the transaction is committed.
+   */
   async commit() {
     if (this.#state !== ProducerState.CONNECTED) {
-      return Promise.reject("Cannot commit without awaiting connect()");
+      throw new error.KafkaJSError("Cannot commit without awaiting connect()", { code: error.ErrorCodes.ERR__STATE });
     }
 
     if (!this.#ongoingTransaction) {
-      return Promise.reject("Cannot commit, no transaction ongoing.");
+      throw new error.KafkaJSError("Cannot commit, no transaction ongoing.", { code: error.ErrorCodes.ERR__STATE });
     }
 
     return new Promise((resolve, reject) => {
       this.#internalClient.commitTransaction(5000 /* default: 5000ms */, err => {
         if (err) {
           // TODO: Do we reset ongoingTransaction here?
-          reject(err);
+          reject(createKafkaJsErrorFromLibRdKafkaError(err));
           return;
         }
         this.#ongoingTransaction = false;
@@ -213,21 +283,24 @@ class Producer {
     });
   }
 
-
+  /**
+   * Abort the current transaction.
+   * @returns {Promise<void>} Resolves when the transaction is aborted.
+   */
   async abort() {
     if (this.#state !== ProducerState.CONNECTED) {
-      return Promise.reject("Cannot abort without awaiting connect()");
+      throw new error.KafkaJSError("Cannot abort without awaiting connect()", { code: error.ErrorCodes.ERR__STATE });
     }
 
     if (!this.#ongoingTransaction) {
-      return Promise.reject("Cannot abort, no transaction ongoing.");
+      throw new error.KafkaJSError("Cannot abort, no transaction ongoing.", { code: error.ErrorCodes.ERR__STATE });
     }
 
     return new Promise((resolve, reject) => {
       this.#internalClient.abortTransaction(5000 /* default: 5000ms */, err => {
         if (err) {
           // TODO: Do we reset ongoingTransaction here?
-          reject(err);
+          reject(createKafkaJsErrorFromLibRdKafkaError(err));
           return;
         }
         this.#ongoingTransaction = false;
@@ -236,19 +309,29 @@ class Producer {
     });
   }
 
+  /**
+   * Send offsets for the transaction.
+   * @param {object} arg - The arguments to sendOffsets
+   * @param {string} arg.consumerGroupId - The consumer group id to send offsets for.
+   * @param {Consumer} arg.consumer - The consumer to send offsets for.
+   * @param {import("../../types/kafkajs").TopicOffsets[]} arg.topics - The topics, partitions and the offsets to send.
+   *
+   * @note only one of consumerGroupId or consumer must be set. It is recommended to use `consumer`.
+   * @returns {Promise<void>} Resolves when the offsets are sent.
+   */
   async sendOffsets(arg) {
     let { consumerGroupId, topics, consumer } = arg;
 
     if ((!consumerGroupId && !consumer) || !Array.isArray(topics) || topics.length === 0) {
-      return Promise.reject("sendOffsets must have the arguments {consumerGroupId: string or consumer: Consumer, topics: non-empty array");
+      throw new error.KafkaJSError("sendOffsets arguments are invalid", { code: error.ErrorCodes.ERR__INVALID_ARG });
     }
 
     if (this.#state !== ProducerState.CONNECTED) {
-      return Promise.reject("Cannot sendOffsets without awaiting connect()");
+      throw new error.KafkaJSError("Cannot sendOffsets without awaiting connect()", { code: error.ErrorCodes.ERR__STATE });
     }
 
     if (!this.#ongoingTransaction) {
-      return Promise.reject("Cannot sendOffsets, no transaction ongoing.");
+      throw new error.KafkaJSError("Cannot sendOffsets, no transaction ongoing.", { code: error.ErrorCodes.ERR__STATE });
     }
 
     // If we don't have a consumer, we must create a consumer at this point internally.
@@ -273,34 +356,44 @@ class Producer {
           if (consumerCreated)
             await consumer.disconnect();
           if (err)
-            reject(err);
+            reject(createKafkaJsErrorFromLibRdKafkaError(err));
           else
             resolve();
         })
     });
   }
 
+  /**
+   *   send(record: ProducerRecord): Promise<RecordMetadata[]>
+
+   * @param {import('../../types/kafkajs').ProducerRecord} sendOptions - The record to send. The keys `acks`, `timeout`, and `compression` are not used, and should not be set, rather, they should be set in the global config.
+   * @returns {Promise<import("../../types/kafkajs").RecordMetadata[]>} Resolves with the record metadata for the messages.
+   */
   async send(sendOptions) {
     if (this.#state !== ProducerState.CONNECTED) {
-      return Promise.reject("Cannot send message without awaiting connect()");
+      throw new error.KafkaJSError("Cannot send without awaiting connect()", { code: error.ErrorCodes.ERR__STATE });
     }
 
     if (sendOptions === null || !(sendOptions instanceof Object)) {
-      return Promise.reject("sendOptions must be set correctly");
+      throw new error.KafkaJSError("sendOptions must be set correctly", { code: error.ErrorCodes.ERR__INVALID_ARG });
     }
 
     // Ignore all properties except topic and messages.
     // TODO: log a warning instead of ignoring.
-    if (!sendOptions.hasOwnProperty("topic") || !sendOptions.hasOwnProperty("messages") || !Array.isArray(sendOptions["messages"])) {
+    if (!Object.hasOwn(sendOptions, "topic") || !Object.hasOwn(sendOptions, "messages") || !Array.isArray(sendOptions["messages"])) {
       // TODO: add further validations.
-      return Promise.reject("sendOptions must be of the form {topic: string, messages: Message[]}");
+      throw new error.KafkaJSError("sendOptions must be of the form {topic: string, messages: Message[]}", { code: error.ErrorCodes.ERR__INVALID_ARG });
+    }
+
+    if (Object.hasOwn(sendOptions, "acks") || Object.hasOwn(sendOptions, "timeout") || Object.hasOwn(sendOptions, "compression")) {
+      throw new error.KafkaJSError("sendOptions must not contain acks, timeout, or compression", { code: error.ErrorCodes.ERR__INVALID_ARG });
     }
 
     const msgPromises = [];
     for (let i = 0; i < sendOptions.messages.length; i++) {
       const msg = sendOptions.messages[i];
 
-      if (!msg.hasOwnProperty("partition") || msg.partition === null) {
+      if (!Object.hasOwn(msg, "partition") || msg.partition === null) {
         msg.partition = -1;
       }
 
@@ -308,12 +401,23 @@ class Producer {
         msg.value = Buffer.from(msg.value);
       }
 
+      if (Object.hasOwn(msg, "timestamp") && msg.timestamp) {
+        msg.timestamp = Number(msg.timestamp);
+      } else {
+        msg.timestamp = 0;
+      }
+
+      msg.headers = convertToRdKafkaHeaders(msg.headers);
+
       msgPromises.push(new Promise((resolve, reject) => {
         const opaque = { resolve, reject };
-        this.#internalClient.produce(sendOptions.topic, msg.partition, msg.value, msg.key, msg.timestamp ?? Date.now(), opaque, msg.headers);
+        this.#internalClient.produce(sendOptions.topic, msg.partition, msg.value, msg.key, msg.timestamp, opaque, msg.headers);
       }));
 
     }
+
+    /* The delivery report will be handled by the delivery-report event handler, and we can simply wait for it here. */
+
     const recordMetadataArr = await Promise.all(msgPromises);
 
     const topicPartitionRecordMetadata = new Map();
@@ -337,7 +441,7 @@ class Producer {
     }
 
     const ret = [];
-    for (const [key, value] of topicPartitionRecordMetadata.entries()) {
+    for (const value of topicPartitionRecordMetadata.values()) {
       value.baseOffset = value.baseOffset?.toString();
       ret.push(value);
     }

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -291,7 +291,7 @@ void DeliveryReportDispatcher::Flush() {
 
     if (event.is_error) {
         // If it is an error we need the first argument to be set
-        argv[0] = Nan::Error(event.error_string.c_str());
+        argv[0] = Nan::New(event.error_code);
     } else {
         argv[0] = Nan::Null();
     }

--- a/types/kafkajs.d.ts
+++ b/types/kafkajs.d.ts
@@ -1,5 +1,5 @@
 import * as tls from 'tls'
-import { ConsumerGlobalConfig, ConsumerTopicConfig, ProducerGlobalConfig, ProducerTopicConfig } from './config'
+import { ConsumerGlobalConfig, ConsumerTopicConfig, GlobalConfig, ProducerGlobalConfig, ProducerTopicConfig, TopicConfig } from './config'
 
 export type BrokersFunction = () => string[] | Promise<string[]>
 
@@ -29,6 +29,7 @@ export interface KafkaConfig {
   reauthenticationThreshold?: number
   requestTimeout?: number
   enforceRequestTimeout?: boolean
+  rdKafka?: Function | { topicConfig?: TopicConfig, globalConfig?: GlobalConfig };
 }
 
 export interface ProducerConfig {


### PR DESCRIPTION
Adds producer errors.

Also includes a separate commit for a C++ change, rationale for which is explained below -
Rationale: 
See `LibrdKafkaError.create`. 

There, we convert the `err` object returned in cpp, to a LibrdKafkaError. In the previous situation, we were just sending the error _message_.  We use this message to initialize the error, and then, it leads to the error code being set to ERR__UNKNOWN.

If we send the error code itself, we can recover the message (since we have a utility to convert from err code to librdkafka error message).