### PR TITLE
fix: memory leak in incremental assign

### DIFF
--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -245,12 +245,15 @@ Baton KafkaConsumer::IncrementalUnassign(std::vector<RdKafka::TopicPartition*> p
 
   RdKafka::Error* error = consumer->incremental_unassign(partitions);
 
+  std::vector<RdKafka::TopicPartition*> delete_partitions;
+
   if (error == NULL) {
     // For now, use two for loops. Make more efficient if needed at a later point.
     for (unsigned int i = 0; i < partitions.size(); i++) {
       for (unsigned int j = 0; j < m_partitions.size(); j++) {
         if (partitions[i]->partition() == m_partitions[j]->partition() &&
             partitions[i]->topic() == m_partitions[j]->topic()) {
+          delete_partitions.insert(delete_partitions.end(), m_partitions.begin() + j, m_partitions.begin() + j + 1);
           m_partitions.erase(m_partitions.begin() + j);
           m_partition_cnt--;
           break;
@@ -260,7 +263,8 @@ Baton KafkaConsumer::IncrementalUnassign(std::vector<RdKafka::TopicPartition*> p
   }
 
   // Destroy the old list of partitions since we are no longer using it
-  RdKafka::TopicPartition::destroy(m_partitions);
+  RdKafka::TopicPartition::destroy(delete_partitions);
+  RdKafka::TopicPartition::destroy(partitions);
 
   return rdkafkaErrorToBaton(error);
 }

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -264,6 +264,9 @@ Baton KafkaConsumer::IncrementalUnassign(std::vector<RdKafka::TopicPartition*> p
 
   // Destroy the old list of partitions since we are no longer using it
   RdKafka::TopicPartition::destroy(delete_partitions);
+
+  // Destroy the partition args since those are only used to lookup the partitions
+  // that needed to be deleted.
   RdKafka::TopicPartition::destroy(partitions);
 
   return rdkafkaErrorToBaton(error);

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -253,7 +253,7 @@ Baton KafkaConsumer::IncrementalUnassign(std::vector<RdKafka::TopicPartition*> p
       for (unsigned int j = 0; j < m_partitions.size(); j++) {
         if (partitions[i]->partition() == m_partitions[j]->partition() &&
             partitions[i]->topic() == m_partitions[j]->topic()) {
-          delete_partitions.insert(delete_partitions.end(), m_partitions.begin() + j, m_partitions.begin() + j + 1);
+          delete_partitions.push_back(m_partitions[j]);
           m_partitions.erase(m_partitions.begin() + j);
           m_partition_cnt--;
           break;


### PR DESCRIPTION
The incremental assign contained a memory leak. This happened because when unassigning, the wrong new pointers are destroyed (m_partitions). 

Instead the `partitions` argument should be destroyed, because this is only used to find the right toppars in m_partitions. And the toppars in `m_partitions` which are unassigned also should be destroyed. 