### PR TITLE
fix: update message header type to match

### DIFF
--- a/types/rdkafka.d.ts
+++ b/types/rdkafka.d.ts
@@ -96,7 +96,8 @@ export interface DeliveryReport extends TopicPartitionOffset {
 export type NumberNullUndefined = number | null | undefined;
 
 export type MessageKey = Buffer | string | null | undefined;
-export type MessageHeader = { [key: string]: string | Buffer };
+export type MessageHeader = string | Buffer;
+export type MessageHeaders = { [key: string]: MessageHeader };
 export type MessageValue = Buffer | null;
 export type SubscribeTopic = string | RegExp;
 export type SubscribeTopicList = SubscribeTopic[];
@@ -107,7 +108,7 @@ export interface Message extends TopicPartitionOffset {
     topic: string;
     key?: MessageKey;
     timestamp?: number;
-    headers?: MessageHeader[];
+    headers?: MessageHeaders;
     opaque?: any;
 }
 
@@ -265,7 +266,7 @@ export class Producer extends Client<KafkaProducerEvents> {
 
     poll(): this;
 
-    produce(topic: string, partition: NumberNullUndefined, message: MessageValue, key?: MessageKey, timestamp?: NumberNullUndefined, opaque?: any, headers?: MessageHeader[]): any;
+    produce(topic: string, partition: NumberNullUndefined, message: MessageValue, key?: MessageKey, timestamp?: NumberNullUndefined, opaque?: any, headers?: MessageHeaders): any;
 
     setPollInterval(interval: number): this;
 
@@ -284,7 +285,7 @@ export class Producer extends Client<KafkaProducerEvents> {
 
 export class HighLevelProducer extends Producer {
   produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, callback: (err: any, offset?: NumberNullUndefined) => void): any;
-  produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, headers: MessageHeader[], callback: (err: any, offset?: NumberNullUndefined) => void): any;
+  produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, headers: MessageHeaders, callback: (err: any, offset?: NumberNullUndefined) => void): any;
 
   setKeySerializer(serializer: (key: any, cb: (err: any, key: MessageKey) => void) => void): void;
   setKeySerializer(serializer: (key: any) => MessageKey | Promise<MessageKey>): void;


### PR DESCRIPTION
The existing MessageHeader type is just a plain object and not an array of plain objects.