### PR TITLE
Fix segfault when passing an undefined matchConsumerGroupStates

### DIFF
--- a/src/admin.cc
+++ b/src/admin.cc
@@ -880,12 +880,15 @@ NAN_METHOD(AdminClient::NodeListGroups) {
       Nan::New("matchConsumerGroupStates").ToLocalChecked();
   bool is_match_states_set =
       Nan::Has(config, match_consumer_group_states_key).FromMaybe(false);
-  v8::Local<v8::Array> match_states_array;
+  v8::Local<v8::Array> match_states_array = Nan::New<v8::Array>();
 
   if (is_match_states_set) {
     match_states_array = GetParameter<v8::Local<v8::Array>>(
         config, "matchConsumerGroupStates", match_states_array);
-    match_states = Conversion::Admin::FromV8GroupStateArray(match_states_array);
+    if (match_states_array->Length()) {
+      match_states = Conversion::Admin::FromV8GroupStateArray(
+        match_states_array);
+    }
   }
 
   // Queue the work.

--- a/test/promisified/admin/list_groups.spec.js
+++ b/test/promisified/admin/list_groups.spec.js
@@ -48,7 +48,9 @@ describe('Admin > listGroups', () => {
         await waitFor(() => consumer.assignment().length > 0, () => null, 1000);
 
         await admin.connect();
-        let listGroupsResult = await admin.listGroups();
+        let listGroupsResult = await admin.listGroups({
+            matchConsumerGroupStates: undefined,
+        });
         expect(listGroupsResult.errors).toEqual([]);
         expect(listGroupsResult.groups).toEqual(
             expect.arrayContaining([


### PR DESCRIPTION
to listGroups