### PR TITLE
Bump version to 0.3.0-RC1 and:

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,20 +220,22 @@ Steps to update:
     node ci/librdkafka-defs-generator.js
     ```
 
-1. Run `npm install --lockfile-version 2` to build with the new version and fix any build errors that occur.
+1. Run `npm install` to build with the new version and fix any build errors that occur.
 
 1. Run unit tests: `npm run test`
+
+1. Change the librdkafka version in `semaphore.yml`
 
 1. Update the version numbers referenced in the [`README.md`](https://github.com/confluentinc/confluent-kafka-javascript/blob/master/README.md) file to the new version.
 
 ## Releasing
 
-1. Increment the `version` in `package.json`. Change the version in `client.js` and `README.md`. Change the librdkafka version in `semaphore.yml` and in `package.json`.
+1. Increment the `version` in `package.json`. Change the version in `util.js` too.
+If it's needed to change librdkafka version, see the **Updating librdkafka version** section.
 
 1. Run `npm install` to update the `package-lock.json` file.
 
-1. Create a PR and merge the above changes, and tag the merged commit with the new version, e.g. `git tag vx.y.z && git push origin vx.y.z`.
-   This should be the same string as `version` in `package.json`.
+1. Create a PR and merge the above changes, and tag the merged commit with the new version. This should be the same string as `version` in `package.json`.
 
 1. The CI will run on the tag, which will create the release artifacts in Semaphore CI.
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,5 +10,11 @@
   "license": "MIT",
   "dependencies": {
     "@confluentinc/kafka-javascript": "file:.."
-  }
+  },
+  "workspaces": [
+    "kafkajs/oauthbearer_calback_authentication",
+    "node-rdkafka/oauthbearer_callback_authentication",
+    "performance",
+    "typescript"
+  ]
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -52,4 +52,4 @@ util.dictToStringList = function (mapOrObject) {
   return list;
 };
 
-util.bindingVersion = 'v0.2.1';
+util.bindingVersion = '0.3.0-RC1';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "@confluentinc/kafka-javascript",
-  "version": "v0.2.1",
+  "version": "0.3.0-RC1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@confluentinc/kafka-javascript",
-      "version": "v0.2.1",
+      "version": "0.3.0-RC1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
+        ".",
+        "examples",
         "schemaregistry",
         "schemaregistry-examples"
       ],
@@ -58,6 +60,19 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "examples": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "workspaces": [
+        "kafkajs/oauthbearer_calback_authentication",
+        "node-rdkafka/oauthbearer_callback_authentication",
+        "performance",
+        "typescript"
+      ],
+      "dependencies": {
+        "@confluentinc/kafka-javascript": "file:.."
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1540,42 +1555,8 @@
       }
     },
     "node_modules/@confluentinc/kafka-javascript": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@confluentinc/kafka-javascript/-/kafka-javascript-0.2.0.tgz",
-      "integrity": "sha512-IWjyGRqeDBcWmYcEQHu1XlZQ6am5qzzIEb18rdxFZkFeVQ6piG28bQ6BmlqvHn3zd+XoAO+e8bRlpgdUuTLC9Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "workspaces": [
-        "schemaregistry"
-      ],
-      "dependencies": {
-        "@aws-sdk/client-kms": "^3.637.0",
-        "@azure/identity": "^4.4.1",
-        "@azure/keyvault-keys": "^4.8.0",
-        "@bufbuild/protobuf": "^2.0.0",
-        "@criteria/json-schema": "^0.10.0",
-        "@criteria/json-schema-validation": "^0.10.0",
-        "@google-cloud/kms": "^4.5.0",
-        "@hackbg/miscreant-esm": "^0.3.2-patch.3",
-        "@mapbox/node-pre-gyp": "^1.0.11",
-        "@smithy/types": "^3.3.0",
-        "@types/simple-oauth2": "^5.0.7",
-        "@types/validator": "^13.12.0",
-        "ajv": "^8.17.1",
-        "async-mutex": "^0.5.0",
-        "avsc": "^5.7.7",
-        "axios": "^1.7.3",
-        "bindings": "^1.3.1",
-        "json-stringify-deterministic": "^1.0.12",
-        "lru-cache": "^11.0.0",
-        "nan": "^2.17.0",
-        "node-vault": "^0.10.2",
-        "simple-oauth2": "^5.1.0",
-        "validator": "^13.12.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
+      "resolved": "",
+      "link": true
     },
     "node_modules/@confluentinc/schemaregistry": {
       "resolved": "schemaregistry",
@@ -5056,6 +5037,10 @@
       "engines": {
         "node": ">=0.8.x"
       }
+    },
+    "node_modules/examples": {
+      "resolved": "examples",
+      "link": true
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -9322,7 +9307,7 @@
     },
     "schemaregistry": {
       "name": "@confluentinc/schemaregistry",
-      "version": "v0.2.1",
+      "version": "0.3.0-RC1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.637.0",
@@ -9349,7 +9334,7 @@
       "devDependencies": {
         "@bufbuild/buf": "^1.37.0",
         "@bufbuild/protoc-gen-es": "^2.0.0",
-        "@confluentinc/kafka-javascript": "^0.2.0",
+        "@confluentinc/kafka-javascript": "file:..",
         "@eslint/js": "^9.9.0",
         "@types/eslint__js": "^8.42.3",
         "@types/node": "^20.16.1",
@@ -9372,8 +9357,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@confluentinc/kafka-javascript": "^0.2.0",
-        "@confluentinc/schemaregistry": "^v0.2.1",
+        "@confluentinc/kafka-javascript": "file:..",
+        "@confluentinc/schemaregistry": "file:../schemaregistry",
         "axios": "^1.7.7",
         "uuid": "^10.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confluentinc/kafka-javascript",
-  "version": "v0.2.1",
+  "version": "0.3.0-RC1",
   "description": "Node.js bindings for librdkafka",
   "librdkafka": "2.6.0",
   "librdkafka_win": "2.6.0",
@@ -78,6 +78,8 @@
     "node": ">=18.0.0"
   },
   "workspaces": [
+    ".",
+    "examples",
     "schemaregistry",
     "schemaregistry-examples"
   ]

--- a/schemaregistry-examples/package.json
+++ b/schemaregistry-examples/package.json
@@ -8,8 +8,8 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@confluentinc/kafka-javascript": "^0.2.0",
-    "@confluentinc/schemaregistry": "^v0.2.1",
+    "@confluentinc/kafka-javascript": "file:..",
+    "@confluentinc/schemaregistry": "file:../schemaregistry",
     "axios": "^1.7.7",
     "uuid": "^10.0.0"
   }

--- a/schemaregistry/package.json
+++ b/schemaregistry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confluentinc/schemaregistry",
-  "version": "v0.2.1",
+  "version": "0.3.0-RC1",
   "description": "Node.js client for Confluent Schema Registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.37.0",
     "@bufbuild/protoc-gen-es": "^2.0.0",
-    "@confluentinc/kafka-javascript": "^0.2.0",
+    "@confluentinc/kafka-javascript": "file:..",
     "@eslint/js": "^9.9.0",
     "@types/eslint__js": "^8.42.3",
     "@types/node": "^20.16.1",


### PR DESCRIPTION
- use workspaces for examples too
- change software version to be without v as other clients
- use relative dev or example dependencies to avoid changing version in multiple places
- updates to RELEASE section