### PR TITLE
Reduce poll timeout and add wakeups for new queue messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ v0.4.0 is a limited availability feature release. It is supported for all usage.
 
 1. Fixes an issue where headers were not passed correctly to the `eachBatch` callback (#130).
 2. Add support for an Admin API to list a consumer group's offsets (#49).
+3. Reduce consumer poll timeout to nil and add wakeups for new messages. This improves
+   the consumer efficiency, and resolves issues while running multiple consumers within
+   the same node process (#135).
 
 
 # confluent-kafka-javascript v0.3.0

--- a/examples/performance/README.md
+++ b/examples/performance/README.md
@@ -3,12 +3,13 @@
 The library can be benchmarked by running the following command:
 
 ```bash
-node performance-consolidated.js [--producer] [--consumer] [--ctp] [--all]
+node performance-consolidated.js [--producer] [--consumer] [--ctp] [--latency] [--all]
 ```
 
 The `--producer` flag will run the producer benchmark, the `--consumer` flag
 will run the consumer benchmark, and the `--ctp` flag will run the
-consume-transform-produce benchmark.
+consume-transform-produce benchmark. The `--latency` flag will run the latency
+test for produce-to-consume latency.
 
 The `--create-topics` flag will create the topics before running the benchmarks
 (and delete any existing topics of the same name). It's recommended to use this
@@ -36,4 +37,6 @@ default values given in parentheses.
 | WARMUP_MESSAGES | Number of messages to produce before starting the produce benchmark | BATCH_SIZE * 10 |
 | MESSAGE_PROCESS_TIME_MS | Time to sleep after consuming each message in the consume-transform-produce benchmark. Simulates "transform". May be 0. | 5 |
 | CONSUME_TRANSFORM_PRODUCE_CONCURRENCY | partitionsConsumedConcurrently for the consume-transform-produce benchmark | 1 |
+| CONSUMER_PROCESSING_TIME | Time to sleep (ms) after consuming each message in the latency benchmark. | 100 |
+| PRODUCER_PROCESSING_TIME | Time to sleep (ms) after producing each message in the latency benchmark. | 100 |
 | MODE | Mode to run the benchmarks in (confluent, kafkajs). Can be used for comparison with KafkaJS | confluent |

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -120,21 +120,10 @@ function KafkaConsumer(conf, topicConf) {
     };
   }
 
-  /**
-   * KafkaConsumer message.
-   *
-   * This is the representation of a message read from Kafka.
-   *
-   * @typedef {object} KafkaConsumer~Message
-   * @property {buffer} value - the message buffer from Kafka.
-   * @property {string} topic - the topic name
-   * @property {number} partition - the partition on the topic the
-   * message was on
-   * @property {number} offset - the offset of the message
-   * @property {string} key - the message key
-   * @property {number} size - message size, in bytes.
-   * @property {number} timestamp - message timestamp
-   */
+  // Note: This configuration is for internal use for now, and hence is not documented, or
+  // exposed via types.
+  const queue_non_empty_cb = conf["js.queue_non_empty_cb"] || null;
+  delete conf["js.queue_non_empty_cb"];
 
   Client.call(this, conf, Kafka.KafkaConsumer, topicConf);
 
@@ -144,6 +133,10 @@ function KafkaConsumer(conf, topicConf) {
   this._consumeTimeout = DEFAULT_CONSUME_TIME_OUT;
   this._consumeLoopTimeoutDelay = DEFAULT_CONSUME_LOOP_TIMEOUT_DELAY;
   this._consumeIsTimeoutOnlyForFirstMessage = DEFAULT_IS_TIMEOUT_ONLY_FOR_FIRST_MESSAGE;
+
+  if (queue_non_empty_cb) {
+    this._cb_configs.event["js.queue_non_empty_cb"] = queue_non_empty_cb.bind(this);
+  }
 }
 
 /**

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -122,8 +122,8 @@ function KafkaConsumer(conf, topicConf) {
 
   // Note: This configuration is for internal use for now, and hence is not documented, or
   // exposed via types.
-  const queue_non_empty_cb = conf["js.queue_non_empty_cb"] || null;
-  delete conf["js.queue_non_empty_cb"];
+  const queue_non_empty_cb = conf.queue_non_empty_cb || null;
+  delete conf.queue_non_empty_cb;
 
   Client.call(this, conf, Kafka.KafkaConsumer, topicConf);
 
@@ -135,7 +135,7 @@ function KafkaConsumer(conf, topicConf) {
   this._consumeIsTimeoutOnlyForFirstMessage = DEFAULT_IS_TIMEOUT_ONLY_FOR_FIRST_MESSAGE;
 
   if (queue_non_empty_cb) {
-    this._cb_configs.event["js.queue_non_empty_cb"] = queue_non_empty_cb.bind(this);
+    this._cb_configs.event.queue_non_empty_cb = queue_non_empty_cb;
   }
 }
 

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -1002,7 +1002,7 @@ class Consumer {
 
     const rdKafkaConfig = this.#config();
     this.#state = ConsumerState.CONNECTING;
-    rdKafkaConfig["js.queue_non_empty_cb"] = this.#queueNonEmptyCb.bind(this);
+    rdKafkaConfig.queue_non_empty_cb = this.#queueNonEmptyCb.bind(this);
     this.#internalClient = new RdKafka.KafkaConsumer(rdKafkaConfig);
     this.#internalClient.on('ready', this.#readyCb.bind(this));
     this.#internalClient.on('error', this.#errorCb.bind(this));

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -170,6 +170,11 @@ class Consumer {
   #fetchInProgress;
 
   /**
+   * Promise that resolves when there is something we need to poll for (messages, rebalance, etc).
+   */
+  #queueNonEmpty = new DeferredPromise();
+
+  /**
    * Whether any rebalance callback is in progress.
    * That can last more than the fetch itself given it's not awaited.
    * So we await it after fetch is done.
@@ -625,6 +630,10 @@ class Consumer {
     /* Slight optimization for cases where the size of messages in our subscription is less than the cache size. */
     this.#internalClient.setDefaultIsTimeoutOnlyForFirstMessage(true);
 
+    // We will fetch only those messages which are already on the queue. Since we will be
+    // woken up by #queueNonEmptyCb, we don't need to set a wait timeout.
+    this.#internalClient.setDefaultConsumeTimeout(0);
+
     this.#clientName = this.#internalClient.name;
     this.#logger.info('Consumer connected', this.#createConsumerBindingMessageMetadata());
 
@@ -993,6 +1002,7 @@ class Consumer {
 
     const rdKafkaConfig = this.#config();
     this.#state = ConsumerState.CONNECTING;
+    rdKafkaConfig["js.queue_non_empty_cb"] = this.#queueNonEmptyCb.bind(this);
     this.#internalClient = new RdKafka.KafkaConsumer(rdKafkaConfig);
     this.#internalClient.on('ready', this.#readyCb.bind(this));
     this.#internalClient.on('error', this.#errorCb.bind(this));
@@ -1259,14 +1269,26 @@ class Consumer {
     return ppc;
   }
 
+  #queueNonEmptyCb() {
+    /* Unconditionally resolve the promise - not a problem if it's already resolved. */
+    this.#queueNonEmpty.resolve();
+  }
+
   async #nextFetchRetry() {
     if (this.#fetchInProgress) {
       await this.#fetchInProgress;
     } else {
       /* Backoff a little. If m is null, we might be without messages
        * or in available partition starvation, and calling consumeSingleCached
-       * in a tight loop will help no one. */
-      await Timer.withTimeout(1);
+       * in a tight loop will help no one. We still keep it to 1000ms because we
+       * want to keep polling, though (ideally) we could increase it all the way
+       * up to max.poll.interval.ms.
+       * In case there is any message in the queue, we'll be woken up before the
+       * timer expires. */
+      await Timer.withTimeout(1000, this.#queueNonEmpty);
+      if (this.#queueNonEmpty.resolved) {
+        this.#queueNonEmpty = new DeferredPromise();
+      }
     }
   }
 

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -652,6 +652,27 @@ void Partitioner::SetCallback(v8::Local<v8::Function> cb) {
   callback(cb);
 }
 
+QueueNotEmptyDispatcher::QueueNotEmptyDispatcher() {}
+QueueNotEmptyDispatcher::~QueueNotEmptyDispatcher() {}
+
+void QueueNotEmptyDispatcher::Flush() {
+  Nan::HandleScope scope;
+
+  const unsigned int argc = 0;
+  Dispatch(argc, nullptr);
+}
+
+QueueNotEmpty::QueueNotEmpty() {}
+QueueNotEmpty::~QueueNotEmpty() {}
+
+void QueueNotEmpty::queue_not_empty_cb(rd_kafka_t *rk, void *self) {
+  QueueNotEmpty *queue_not_empty = static_cast<QueueNotEmpty *>(self);
+  if (!queue_not_empty->dispatcher.HasCallbacks()) {
+    return;
+  }
+
+  queue_not_empty->dispatcher.Execute();
+}
 
 }  // end namespace Callbacks
 

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -279,6 +279,26 @@ class Partitioner : public RdKafka::PartitionerCb {
   static unsigned int random(const RdKafka::Topic*, int32_t);
 };
 
+class QueueNotEmptyDispatcher : public Dispatcher {
+ public:
+  QueueNotEmptyDispatcher();
+  ~QueueNotEmptyDispatcher();
+  void Flush();
+};
+
+// This callback does not extend from any class because it's a C callback
+// The only reason we have a class here is to maintain similarity with how
+// callbacks are structured in the rest of the library.
+class QueueNotEmpty {
+ public:
+  QueueNotEmpty();
+  ~QueueNotEmpty();
+  // This is static because it must be passed to C. The `this` reference will be
+  // passde within `self`.
+  static void queue_not_empty_cb(rd_kafka_t *rk, void *self);
+  QueueNotEmptyDispatcher dispatcher;
+};
+
 }  // namespace Callbacks
 
 }  // namespace NodeKafka

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -77,6 +77,11 @@ Baton KafkaConsumer::Connect() {
     m_client->resume(m_partitions);
   }
 
+  rd_kafka_queue_t* queue = rd_kafka_queue_get_consumer(m_client->c_ptr());
+  rd_kafka_queue_cb_event_enable(
+      queue, &m_queue_not_empty_cb.queue_not_empty_cb, &m_queue_not_empty_cb);
+  rd_kafka_queue_destroy(queue);
+
   return Baton(RdKafka::ERR_NO_ERROR);
 }
 
@@ -89,6 +94,7 @@ void KafkaConsumer::ActivateDispatchers() {
 
   // This should be refactored to config based management
   m_event_cb.dispatcher.Activate();
+  m_queue_not_empty_cb.dispatcher.Activate();
 }
 
 Baton KafkaConsumer::Disconnect() {
@@ -119,6 +125,21 @@ void KafkaConsumer::DeactivateDispatchers() {
 
   // Also this one
   m_event_cb.dispatcher.Deactivate();
+  m_queue_not_empty_cb.dispatcher.Deactivate();
+}
+
+void KafkaConsumer::ConfigureCallback(const std::string& string_key,
+                                      const v8::Local<v8::Function>& cb,
+                                      bool add) {
+  if (string_key.compare("js.queue_non_empty_cb") == 0) {
+    if (add) {
+      this->m_queue_not_empty_cb.dispatcher.AddCallback(cb);
+    } else {
+      this->m_queue_not_empty_cb.dispatcher.RemoveCallback(cb);
+    }
+  } else {
+    Connection::ConfigureCallback(string_key, cb, add);
+  }
 }
 
 bool KafkaConsumer::IsSubscribed() {

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -131,7 +131,7 @@ void KafkaConsumer::DeactivateDispatchers() {
 void KafkaConsumer::ConfigureCallback(const std::string& string_key,
                                       const v8::Local<v8::Function>& cb,
                                       bool add) {
-  if (string_key.compare("js.queue_non_empty_cb") == 0) {
+  if (string_key.compare("queue_non_empty_cb") == 0) {
     if (add) {
       this->m_queue_not_empty_cb.dispatcher.AddCallback(cb);
     } else {

--- a/src/kafka-consumer.h
+++ b/src/kafka-consumer.h
@@ -107,7 +107,7 @@ class KafkaConsumer : public Connection {
   bool m_is_subscribed = false;
 
   void* m_consume_loop = nullptr;
-  NodeKafka::Callbacks::QueueNotEmpty m_queue_not_empty_cb;
+  Callbacks::QueueNotEmpty m_queue_not_empty_cb;
 
   /* This is the same client as stored in m_client.
    * Prevents a dynamic_cast in every single method. */

--- a/src/kafka-consumer.h
+++ b/src/kafka-consumer.h
@@ -89,6 +89,9 @@ class KafkaConsumer : public Connection {
   void ActivateDispatchers();
   void DeactivateDispatchers();
 
+  void ConfigureCallback(const std::string& string_key,
+                         const v8::Local<v8::Function>& cb, bool add) override;
+
  protected:
   static Nan::Persistent<v8::Function> constructor;
   static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
@@ -104,6 +107,7 @@ class KafkaConsumer : public Connection {
   bool m_is_subscribed = false;
 
   void* m_consume_loop = nullptr;
+  NodeKafka::Callbacks::QueueNotEmpty m_queue_not_empty_cb;
 
   /* This is the same client as stored in m_client.
    * Prevents a dynamic_cast in every single method. */


### PR DESCRIPTION
## Description

Earlier, we were polling with the default timeout of 1 second. Each poll, while it doesn't block the JS main thread, blocks one of the worker threads used by the libuv thread pool, and thus, if the number of consumers exceeds thread pool size, we can be blocked from polling any more, especially if the consumers are idle. The blocking seems to just cause the threads to sleep.

See #124 

## Solution

* First step: reduce polling interval. So in case there are no messages, we return immediately. The downside of this is that it increases CPU usage - since we are continuously calling poll, we aren't "sleeping" as we should.
* Second step: increase the backoff time between polls. Current the backoff is 1ms (just to allow us to yield to any pending callbacks etc.). Increasing this to 1000ms makes the CPU usage okay. The problem, that now if we don't get a message, we might get it up to 1000ms late.
* Third step: keep the backoff as 1000ms, but allow it to be "interrupted". This is done by using a callback that's triggered spontaneously whenever the number of messages on the queue goes from none to 1.

## Testing

* Correctness:
Ran all promisified consumer integration tests.

* Checking Performance
Using the example provided by Aaron in #124 (the 32 consumers case), and setting the libuv threadpool size to 1. Before my change it exceeds my 120 second timeout, post my change:
```
...
[Received] @ test-confluent-topic-0 (#16 of 16): Confluent Message 16 (920ms)
```

* Checking Latency
Using the newly added performance benchmark for measuring produce-to-consume latency. Why did I choose these two tests? The "produce and consume rates are same" represents a 'normal' case where consumer is consuming with just enough resources and no lag, and "consume is 2x faster than produce" represents a case where a consumer will be idling (sleeping) and gets a message suddenly.
  * Pre-change, produce and consume rates are same: `Latency (ms): Mean: 2.25, P50: 2.213837, P90: 3.106265, P95: 3.543664`
  * Pre-change, consume is 2x faster than produce: ` Latency (ms): Mean: 2.16, P50: 2.086145, P90: 3.171074, P95: 3.517486`
  * Post-change, produce and consume rates are same: `Latency (ms): Mean: 1.62, P50: 1.347706, P90: 2.281642, P95: 2.601821`
  * Post change, consume is 2x faster than produce: `Latency (ms): Mean: 2.23, P50: 1.530834, P90: 2.32475, P95: 2.427517`

The results bear out that pre- and post-change, the latency is pretty much the same (I believe the ~1-2ms latency is honestly just because of my system and the variation isn't very meaningful, KafkaJS has similar latencies). 
However, I feel the need to call out that the number of outliers post-change is a _tiny_ bit more (0.8% vs 0.6% over 1000 messages). Outlier is a message taking more than 10x the P50 latency. (But then, our P50 is lesser post change, so it could just be a bad thing to look for...)

* Checking cpu usage
I ran the test in #124 again. I used `time` so that counts all the setup time and produce time too, but I think the difference is large enough for that to not be too important. Thread pool size was 1 again.
  * Tests run JUST by changing poll time to 0 (without wakeup cb): `actual time: 0:55.97 cpu percent: 103% user mode seconds: 47.72`
  * Tests run with my complete changes: `actual time: 0:27.96 cpu percent: 6% user mode seconds: 1.26`

So yeah, I think that is promising. The consumer init (waiting for rebalance) has also become much quicker, hence the reduction in the actual time.