### PR TITLE
Fix Protobuf field transform to use schema from SR

### DIFF
--- a/schemaregistry/serde/avro.ts
+++ b/schemaregistry/serde/avro.ts
@@ -285,7 +285,7 @@ async function transform(ctx: RuleContext, schema: Type, msg: any, fieldTransfor
       const recordSchema = schema as RecordType
       const record = msg as Record<string, any>
       for (const field of recordSchema.fields) {
-        await transformField(ctx, recordSchema, field, record, record[field.name], fieldTransform)
+        await transformField(ctx, recordSchema, field, record, fieldTransform)
       }
       return record
     default:
@@ -304,13 +304,12 @@ async function transformField(
   recordSchema: RecordType,
   field: Field,
   record: Record<string, any>,
-  val: any,
   fieldTransform: FieldTransform,
 ): Promise<void> {
   const fullName = recordSchema.name + '.' + field.name
   try {
     ctx.enterField(
-      val,
+      record,
       fullName,
       field.name,
       getType(field.type),

--- a/schemaregistry/serde/json.ts
+++ b/schemaregistry/serde/json.ts
@@ -350,8 +350,7 @@ async function transform(ctx: RuleContext, schema: DereferencedJSONSchema, path:
     case FieldType.RECORD:
       if (schema.properties != null) {
         for (let [propName, propSchema] of Object.entries(schema.properties)) {
-          let value = msg[propName]
-          await transformField(ctx, path, propName, msg, value, propSchema, fieldTransform)
+          await transformField(ctx, path, propName, msg, propSchema, fieldTransform)
         }
       }
       return msg
@@ -371,12 +370,13 @@ async function transform(ctx: RuleContext, schema: DereferencedJSONSchema, path:
   return msg
 }
 
-async function transformField(ctx: RuleContext, path: string, propName: string, msg: any, value: any,
-                        propSchema: DereferencedJSONSchema,
-                        fieldTransform: FieldTransform): Promise<void> {
+async function transformField(ctx: RuleContext, path: string, propName: string, msg: any,
+                              propSchema: DereferencedJSONSchema,
+                              fieldTransform: FieldTransform): Promise<void> {
   const fullName = path + '.' + propName
   try {
     ctx.enterField(msg, fullName, propName, getType(propSchema), getInlineTags(propSchema))
+    let value = msg[propName]
     const newVal = await transform(ctx, propSchema, fullName, value, fieldTransform)
     if (ctx.rule.kind === 'CONDITION') {
       if (newVal === false) {

--- a/schemaregistry/serde/protobuf.ts
+++ b/schemaregistry/serde/protobuf.ts
@@ -509,7 +509,7 @@ async function transform(ctx: RuleContext, descriptor: DescMessage, msg: any, fi
 }
 
 async function transformField(ctx: RuleContext, fd: DescField, desc: DescMessage,
-                        msg: any, fieldTransform: FieldTransform) {
+                              msg: any, fieldTransform: FieldTransform) {
   try {
     ctx.enterField(
       msg,


### PR DESCRIPTION
Fix Protobuf field transform to use schema from SR.  Previously the code was using the schema from the local Proto registry instead of from SR.