### PR TITLE
Bump version to 0.4.0-RC2

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -416,7 +416,7 @@ blocks:
           type: s1-prod-macos-13-5-amd64
       env_vars:
         - name: ARCHITECTURE
-          value: "amd64"
+          value: "x64"
         - name: PLATFORM
           value: "darwin"
         - name: LIBC

--- a/lib/util.js
+++ b/lib/util.js
@@ -52,4 +52,4 @@ util.dictToStringList = function (mapOrObject) {
   return list;
 };
 
-util.bindingVersion = '0.4.0-RC1';
+util.bindingVersion = '0.4.0-RC2';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@confluentinc/kafka-javascript",
-  "version": "0.4.0-RC1",
+  "version": "0.4.0-RC2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@confluentinc/kafka-javascript",
-      "version": "0.4.0-RC1",
+      "version": "0.4.0-RC2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -9300,7 +9300,7 @@
     },
     "schemaregistry": {
       "name": "@confluentinc/schemaregistry",
-      "version": "0.4.0-RC1",
+      "version": "0.4.0-RC2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.637.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confluentinc/kafka-javascript",
-  "version": "0.4.0-RC1",
+  "version": "0.4.0-RC2",
   "description": "Node.js bindings for librdkafka",
   "librdkafka": "2.6.0",
   "librdkafka_win": "2.6.0",

--- a/schemaregistry/package.json
+++ b/schemaregistry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confluentinc/schemaregistry",
-  "version": "0.4.0-RC1",
+  "version": "0.4.0-RC2",
   "description": "Node.js client for Confluent Schema Registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Successful run here: https://semaphore.ci.confluent.io/workflows/1fa3208b-dc10-4029-b9c5-d8ba04f296c5?pipeline_id=a7b97032-a169-4e38-a68d-47d2d9742d92

There is one failure which is intermittent (probably the nodejs site rate limiting us). Here is a successful run of that particular failure: https://semaphore.ci.confluent.io/jobs/43c09a54-402e-4b7a-9d36-22aa6f7ce48b