### PR TITLE
Revert moving ActivateDispatchers to worker Execute

### DIFF
--- a/src/workers.cc
+++ b/src/workers.cc
@@ -199,11 +199,6 @@ ProducerConnect::ProducerConnect(Nan::Callback *callback, Producer* producer):
 ProducerConnect::~ProducerConnect() {}
 
 void ProducerConnect::Execute() {
-  // Activate the dispatchers before the connection, as some callbacks may run
-  // on the background thread.
-  // We will deactivate them if the connection fails.
-  producer->ActivateDispatchers();
-
   Baton b = producer->Connect();
 
   if (b.err() != RdKafka::ERR_NO_ERROR) {
@@ -221,6 +216,9 @@ void ProducerConnect::HandleOKCallback() {
     Nan::New(producer->Name()).ToLocalChecked());
 
   v8::Local<v8::Value> argv[argc] = { Nan::Null(), obj};
+
+  // Activate the dispatchers
+  producer->ActivateDispatchers();
 
   callback->Call(argc, argv);
 }
@@ -558,11 +556,6 @@ KafkaConsumerConnect::KafkaConsumerConnect(Nan::Callback *callback,
 KafkaConsumerConnect::~KafkaConsumerConnect() {}
 
 void KafkaConsumerConnect::Execute() {
-  // Activate the dispatchers before the connection, as some callbacks may run
-  // on the background thread.
-  // We will deactivate them if the connection fails.
-  consumer->ActivateDispatchers();
-
   Baton b = consumer->Connect();
   // consumer->Wait();
 
@@ -582,6 +575,7 @@ void KafkaConsumerConnect::HandleOKCallback() {
     Nan::New(consumer->Name()).ToLocalChecked());
 
   v8::Local<v8::Value> argv[argc] = { Nan::Null(), obj };
+  consumer->ActivateDispatchers();
 
   callback->Call(argc, argv);
 }


### PR DESCRIPTION
Fixes #161 by moving `ActivateDispatchers` back to `HandleOKCallback`. We're using this fix on a fork, and have verified that it fixes the hang.