### PR TITLE
Move activation of dispatchers into event loop thread

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -106,7 +106,7 @@ blocks:
             - '[[ -z $DOCKERHUB_APIKEY ]] || docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY'
             - docker compose up -d && sleep 30
             - export NODE_OPTIONS='--max-old-space-size=1536'
-            - npx jest --forceExit --no-colors --ci test/promisified/
+            - npx jest --no-colors --ci test/promisified/
         - name: "ESLint"
           commands:
             - npx eslint lib/kafkajs

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -106,7 +106,7 @@ blocks:
             - '[[ -z $DOCKERHUB_APIKEY ]] || docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY'
             - docker compose up -d && sleep 30
             - export NODE_OPTIONS='--max-old-space-size=1536'
-            - npx jest --forceExit --no-colors --ci test/promisified/admin/delete_groups.spec.js test/promisified/consumer/pause.spec.js
+            - npx jest --forceExit --no-colors --ci test/promisified/
         - name: "ESLint"
           commands:
             - npx eslint lib/kafkajs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# confluent-kafka-javascript v0.5.3
+
+v0.5.3 is a limited availability maintenance release. It is supported for all usage.
+
+## Fixes
+
+1. Fixes an issue where `uv_async_init` was being called off the event loop thread,
+   causing the node process to hang (#190).
+
+
 # confluent-kafka-javascript v0.5.2
 
 v0.5.2 is a limited availability maintenance release. It is supported for all usage.

--- a/lib/kafkajs/_admin.js
+++ b/lib/kafkajs/_admin.js
@@ -63,6 +63,13 @@ class Admin {
   #connectPromiseFunc = null;
 
   /**
+   * Stores the first error encountered while connecting (if any). This is what we
+   * want to reject with.
+   * @type {Error|null}
+   */
+  #connectionError = null;
+
+  /**
    * The client name used by the admin client for logging - determined by librdkafka
    * using a combination of clientId and an integer.
    * @type {string|undefined}
@@ -169,9 +176,10 @@ class Admin {
    * @param {Error} err
    */
   #errorCb(err) {
-    if (this.#state === AdminState.CONNECTING) {
-      this.#state = AdminState.DISCONNECTED;
-      this.#connectPromiseFunc['reject'](err);
+    /* If we get an error in the middle of connecting, reject the promise later with this error. */
+    if (this.#state < AdminState.CONNECTED) {
+      if (!this.#connectionError)
+        this.#connectionError = err;
     } else {
       this.#logger.error(`Error: ${err.message}`, this.#createAdminBindingMessageMetadata());
     }
@@ -213,7 +221,9 @@ class Admin {
         this.#clientName = this.#internalClient.name;
         this.#logger.info("Admin client connected", this.#createAdminBindingMessageMetadata());
       } catch (err) {
-        reject(createKafkaJsErrorFromLibRdKafkaError(err));
+        this.#state = AdminState.DISCONNECTED;
+        const rejectionError = this.#connectionError ? this.#connectionError : err;
+        reject(createKafkaJsErrorFromLibRdKafkaError(rejectionError));
       }
     });
   }

--- a/lib/kafkajs/_admin.js
+++ b/lib/kafkajs/_admin.js
@@ -170,6 +170,7 @@ class Admin {
    */
   #errorCb(err) {
     if (this.#state === AdminState.CONNECTING) {
+      this.#state = AdminState.DISCONNECTED;
       this.#connectPromiseFunc['reject'](err);
     } else {
       this.#logger.error(`Error: ${err.message}`, this.#createAdminBindingMessageMetadata());

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -66,6 +66,13 @@ class Consumer {
   #connectPromiseFunc = {};
 
   /**
+   * Stores the first error encountered while connecting (if any). This is what we
+   * want to reject with.
+   * @type {Error|null}
+   */
+  #connectionError = null;
+
+  /**
    * state is the current state of the consumer.
    * @type {ConsumerState}
    */
@@ -668,9 +675,10 @@ class Consumer {
    * @param {Error} err
    */
   #errorCb(err) {
-    if (this.#state === ConsumerState.CONNECTING) {
-      this.#state = ConsumerState.DISCONNECTED;
-      this.#connectPromiseFunc['reject'](err);
+    /* If we get an error in the middle of connecting, reject the promise later with this error. */
+    if (this.#state < ConsumerState.CONNECTED) {
+      if (!this.#connectionError)
+        this.#connectionError = err;
     } else {
       this.#logger.error(err, this.#createConsumerBindingMessageMetadata());
     }
@@ -1028,8 +1036,11 @@ class Consumer {
     return new Promise((resolve, reject) => {
       this.#connectPromiseFunc = { resolve, reject };
       this.#internalClient.connect(null, (err) => {
-        if (err)
-          reject(createKafkaJsErrorFromLibRdKafkaError(err));
+        if (err) {
+          this.#state = ConsumerState.DISCONNECTED;
+          const rejectionError = this.#connectionError ? this.#connectionError : err;
+          reject(createKafkaJsErrorFromLibRdKafkaError(rejectionError));
+        }
       });
     });
   }

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -669,6 +669,7 @@ class Consumer {
    */
   #errorCb(err) {
     if (this.#state === ConsumerState.CONNECTING) {
+      this.#state = ConsumerState.DISCONNECTED;
       this.#connectPromiseFunc['reject'](err);
     } else {
       this.#logger.error(err, this.#createConsumerBindingMessageMetadata());

--- a/lib/kafkajs/_producer.js
+++ b/lib/kafkajs/_producer.js
@@ -331,6 +331,7 @@ class Producer {
    */
   #errorCb(err) {
     if (this.#state === ProducerState.CONNECTING) {
+      this.#state = ProducerState.DISCONNECTED;
       this.#connectPromiseFunc["reject"](err);
     } else {
       this.#logger.error(err, this.#createProducerBindingMessageMetadata());

--- a/lib/kafkajs/_producer.js
+++ b/lib/kafkajs/_producer.js
@@ -59,6 +59,13 @@ class Producer {
   #connectPromiseFunc = {};
 
   /**
+   * Stores the first error encountered while connecting (if any). This is what we
+   * want to reject with.
+   * @type {Error|null}
+   */
+  #connectionError = null;
+
+  /**
    * state is the current state of the producer.
    * @type {ProducerState}
    */
@@ -330,12 +337,12 @@ class Producer {
    * @param {Error} err
    */
   #errorCb(err) {
-    if (this.#state === ProducerState.CONNECTING) {
-      this.#state = ProducerState.DISCONNECTED;
-      this.#connectPromiseFunc["reject"](err);
-    } else {
-      this.#logger.error(err, this.#createProducerBindingMessageMetadata());
+    /* If we get an error in the middle of connecting, reject the promise later with this error. */
+    if (this.#state < ProducerState.CONNECTED) {
+      if (!this.#connectionError)
+        this.#connectionError = err;
     }
+    this.#logger.error(err, this.#createProducerBindingMessageMetadata());
   }
 
   /**
@@ -360,8 +367,11 @@ class Producer {
     return new Promise((resolve, reject) => {
       this.#connectPromiseFunc = { resolve, reject };
       this.#internalClient.connect(null, (err) => {
-        if (err)
-          reject(createKafkaJsErrorFromLibRdKafkaError(err));
+        if (err) {
+          this.#state = ProducerState.DISCONNECTED;
+          const rejectionError = this.#connectionError ? this.#connectionError : err;
+          reject(createKafkaJsErrorFromLibRdKafkaError(rejectionError));
+        }
       });
     });
   }

--- a/src/admin.cc
+++ b/src/admin.cc
@@ -56,11 +56,6 @@ Baton AdminClient::Connect() {
     return baton;
   }
 
-  // Activate the dispatchers before the connection, as some callbacks may run
-  // on the background thread.
-  // We will deactivate them if the connection fails.
-  ActivateDispatchers();
-
   std::string errstr;
   {
     scoped_shared_write_lock lock(m_connection_lock);
@@ -929,6 +924,11 @@ NAN_METHOD(AdminClient::NodeConnect) {
   Nan::HandleScope scope;
 
   AdminClient* client = ObjectWrap::Unwrap<AdminClient>(info.This());
+
+  // Activate the dispatchers before the connection, as some callbacks may run
+  // on the background thread.
+  // We will deactivate them if the connection fails.
+  client->ActivateDispatchers();
 
   Baton b = client->Connect();
   // Let the JS library throw if we need to so the error can be more rich

--- a/src/admin.cc
+++ b/src/admin.cc
@@ -928,6 +928,9 @@ NAN_METHOD(AdminClient::NodeConnect) {
   // Activate the dispatchers before the connection, as some callbacks may run
   // on the background thread.
   // We will deactivate them if the connection fails.
+  // Because the Admin Client connect is synchronous, we can do this within
+  // AdminClient::Connect as well, but we do it here to keep the code similiar to
+  // the Producer and Consumer.
   client->ActivateDispatchers();
 
   Baton b = client->Connect();

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -1450,6 +1450,11 @@ NAN_METHOD(KafkaConsumer::NodeConnect) {
 
   KafkaConsumer* consumer = ObjectWrap::Unwrap<KafkaConsumer>(info.This());
 
+  // Activate the dispatchers before the connection, as some callbacks may run
+  // on the background thread.
+  // We will deactivate them if the connection fails.
+  consumer->ActivateDispatchers();
+
   Nan::Callback *callback = new Nan::Callback(info[0].As<v8::Function>());
   Nan::AsyncQueueWorker(new Workers::KafkaConsumerConnect(callback, consumer));
 

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -730,10 +730,8 @@ NAN_METHOD(Producer::NodeConnect) {
 
   Producer* producer = ObjectWrap::Unwrap<Producer>(info.This());
 
-  // Activate the dispatchers before starting the async worker, as it must be
-  // done on the event loop thread.
-  // Some callbacks may run on the librdkafka background thread so this cannot
-  // wait until RdKafka::Producer has been created.
+  // Activate the dispatchers before the connection, as some callbacks may run
+  // on the background thread.
   // We will deactivate them if the connection fails.
   producer->ActivateDispatchers();
 

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -729,6 +729,14 @@ NAN_METHOD(Producer::NodeConnect) {
   Nan::Callback *callback = new Nan::Callback(cb);
 
   Producer* producer = ObjectWrap::Unwrap<Producer>(info.This());
+
+  // Activate the dispatchers before starting the async worker, as it must be
+  // done on the event loop thread.
+  // Some callbacks may run on the librdkafka background thread so this cannot
+  // wait until RdKafka::Producer has been created.
+  // We will deactivate them if the connection fails.
+  producer->ActivateDispatchers();
+
   Nan::AsyncQueueWorker(new Workers::ProducerConnect(callback, producer));
 
   info.GetReturnValue().Set(Nan::Null());

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -199,11 +199,6 @@ ProducerConnect::ProducerConnect(Nan::Callback *callback, Producer* producer):
 ProducerConnect::~ProducerConnect() {}
 
 void ProducerConnect::Execute() {
-  // Activate the dispatchers before the connection, as some callbacks may run
-  // on the background thread.
-  // We will deactivate them if the connection fails.
-  producer->ActivateDispatchers();
-
   Baton b = producer->Connect();
 
   if (b.err() != RdKafka::ERR_NO_ERROR) {
@@ -558,11 +553,6 @@ KafkaConsumerConnect::KafkaConsumerConnect(Nan::Callback *callback,
 KafkaConsumerConnect::~KafkaConsumerConnect() {}
 
 void KafkaConsumerConnect::Execute() {
-  // Activate the dispatchers before the connection, as some callbacks may run
-  // on the background thread.
-  // We will deactivate them if the connection fails.
-  consumer->ActivateDispatchers();
-
   Baton b = consumer->Connect();
   // consumer->Wait();
 

--- a/test/promisified/oauthbearer_cb.spec.js
+++ b/test/promisified/oauthbearer_cb.spec.js
@@ -33,7 +33,7 @@ describe('Client > oauthbearer callback', () => {
             });
 
             await expect(client.connect()).rejects.toThrow('oauthbearer_cb error');
-            expect(oauthbearer_cb_called).toEqual(1);
+            expect(oauthbearer_cb_called).toBeGreaterThanOrEqual(1);
             await client.disconnect();
         }
     );
@@ -51,7 +51,7 @@ describe('Client > oauthbearer callback', () => {
             });
 
             await expect(client.connect()).rejects.toThrow('oauthbearer_cb error');
-            expect(oauthbearer_cb_called).toEqual(1);
+            expect(oauthbearer_cb_called).toBeGreaterThanOrEqual(1);
             await client.disconnect();
         }
     );
@@ -72,7 +72,7 @@ describe('Client > oauthbearer callback', () => {
             await expect(client.connect()).resolves.toBeUndefined();
 
             await sleep(2000); // Wait for the callback to be called
-            expect(oauthbearer_cb_called).toEqual(1);
+            expect(oauthbearer_cb_called).toBeGreaterThanOrEqual(1);
             await client.disconnect();
         }
     );

--- a/test/promisified/testhelpers.js
+++ b/test/promisified/testhelpers.js
@@ -19,8 +19,8 @@ function makeConfig(config, common) {
     const kafkaJS =  Object.assign(config, clusterInformation.kafkaJS);
     if (debug) {
         common['debug'] = debug;
-    } else { /* Turn off info logging unless specifically asked for, otherwise stdout gets very crowded. */
-        common['log_level'] = 1;
+    } else { /* Turn off excessive logging unless specifically asked for, otherwise stdout gets very crowded. */
+        common['log_level'] = 5;
     }
 
     return Object.assign(common, { kafkaJS });
@@ -140,5 +140,6 @@ module.exports = {
     sleep,
     generateMessages,
     clusterInformation,
-    SequentialPromises
+    SequentialPromises,
+    DeferredPromise,
 };

--- a/test/promisified/testhelpers.js
+++ b/test/promisified/testhelpers.js
@@ -19,6 +19,8 @@ function makeConfig(config, common) {
     const kafkaJS =  Object.assign(config, clusterInformation.kafkaJS);
     if (debug) {
         common['debug'] = debug;
+    } else { /* Turn off info logging unless specifically asked for, otherwise stdout gets very crowded. */
+        common['log_level'] = 1;
     }
 
     return Object.assign(common, { kafkaJS });
@@ -52,6 +54,8 @@ async function createTopic(args) {
             { topic, numPartitions: partitions ?? 1 }
         ]
     });
+    /* Wait for topic to propagate in the metadata. */
+    await sleep(500);
     await admin.disconnect();
 }
 


### PR DESCRIPTION
1. Reduce test flakiness by adding some time for metadata to propagate, adding some 'sleep's, and disabling two tests which are flaky for librdkafka-reasons. Change group desc. test to account for the possibility of empty->dead state transition. 
2. Move the event-loop-thread specific stuff onto that thread.
3. See if this makes tests run on semaphore consistently.