### PR TITLE
Add AWS AssumeRole support to AWS KMS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,549 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.699.0.tgz",
+      "integrity": "sha512-9tFt+we6AIvj/f1+nrLHuCWcQmyfux5gcBSOy9d9+zIG56YxGEX7S9TaZnybogpVV8A0BYWml36WvIHS9QjIpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/client-sts": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.696.0.tgz",
+      "integrity": "sha512-q5TTkd08JS0DOkHfUL853tuArf7NrPeqoS5UOvqJho8ibV9Ak/a/HO4kNvy9Nj3cib/toHYHsQIEtecUPSUUrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.699.0.tgz",
+      "integrity": "sha512-u8a1GorY5D1l+4FQAf4XBUC1T10/t7neuwT21r0ymrtMFSK2a9QqVHKMoLkvavAwyhJnARSBM9/UQC797PFOFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.699.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.699.0.tgz",
+      "integrity": "sha512-++lsn4x2YXsZPIzFVwv3fSUVM55ZT0WRFmPeNilYIhZClxHLmVAWKH4I55cY9ry60/aTKYjzOXkWwyBKGsGvQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/core": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.696.0.tgz",
+      "integrity": "sha512-3c9III1k03DgvRZWg8vhVmfIXPG6hAciN9MzQTzqGngzWAELZF/WONRTRQuDFixVtarQatmLHYVw/atGeA2Byw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/signature-v4": "^4.2.2",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-middleware": "^3.0.10",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.696.0.tgz",
+      "integrity": "sha512-T9iMFnJL7YTlESLpVFT3fg1Lkb1lD+oiaIC8KMpepb01gDUBIpj9+Y+pA/cgRWW0yRxmkDXNazAE2qQTVFGJzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.696.0.tgz",
+      "integrity": "sha512-GV6EbvPi2eq1+WgY/o2RFA3P7HGmnkIzCNmhwtALFlqMroLYWKE7PSeHw66Uh1dFQeVESn0/+hiUNhu1mB0emA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-stream": "^3.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.699.0.tgz",
+      "integrity": "sha512-dXmCqjJnKmG37Q+nLjPVu22mNkrGHY8hYoOt3Jo9R2zr5MYV7s/NHsCHr+7E+BZ+tfZYLRPeB1wkpTeHiEcdRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.699.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.699.0.tgz",
+      "integrity": "sha512-MmEmNDo1bBtTgRmdNfdQksXu4uXe66s0p1hi1YPrn1h59Q605eq/xiWbGL6/3KdkViH6eGUuABeV2ODld86ylg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-ini": "3.699.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.696.0.tgz",
+      "integrity": "sha512-mL1RcFDe9sfmyU5K1nuFkO8UiJXXxLX4JO1gVaDIOvPqwStpUAwi3A1BoeZhWZZNQsiKI810RnYGo0E0WB/hUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.699.0.tgz",
+      "integrity": "sha512-Ekp2cZG4pl9D8+uKWm4qO1xcm8/MeiI8f+dnlZm8aQzizeC+aXYy9GyoclSf6daK8KfRPiRfM7ZHBBL5dAfdMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.696.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/token-providers": "3.699.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.696.0.tgz",
+      "integrity": "sha512-XJ/CVlWChM0VCoc259vWguFUjJDn/QwDqHwbx+K9cg3v6yrqXfK5ai+p/6lx0nQpnk4JzPVeYYxWRpaTsGC9rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.696.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.696.0.tgz",
+      "integrity": "sha512-zELJp9Ta2zkX7ELggMN9qMCgekqZhFC5V2rOr4hJDEb/Tte7gpfKSObAnw/3AYiVqt36sjHKfdkoTsuwGdEoDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.696.0.tgz",
+      "integrity": "sha512-KhkHt+8AjCxcR/5Zp3++YPJPpFQzxpr+jmONiT/Jw2yqnSngZ0Yspm5wGoRx2hS1HJbyZNuaOWEGuJoxLeBKfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.696.0.tgz",
+      "integrity": "sha512-si/maV3Z0hH7qa99f9ru2xpS5HlfSVcasRlNUXKSDm611i7jFMWwGNLUOXFAOLhXotPX5G3Z6BLwL34oDeBMug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.696.0.tgz",
+      "integrity": "sha512-Lvyj8CTyxrHI6GHd2YVZKIRI5Fmnugt3cpJo0VrKKEgK5zMySwEZ1n4dqPK6czYRWKd5+WnYHYAuU+Wdk6Jsjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.696.0.tgz",
+      "integrity": "sha512-7EuH142lBXjI8yH6dVS/CZeiK/WZsmb/8zP6bQbVYpMrppSTgB3MzZZdxVZGzL5r8zPQOU10wLC4kIMy0qdBVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.699.0.tgz",
+      "integrity": "sha512-kuiEW9DWs7fNos/SM+y58HCPhcIzm1nEZLhe2/7/6+TvAYLuEWURYsbK48gzsxXlaJ2k/jGY3nIsA7RptbMOwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.699.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.696.0.tgz",
+      "integrity": "sha512-9rTvUJIAj5d3//U5FDPWGJ1nFJLuWb30vugGOrWk7aNZ6y9tuA3PI7Cc9dP8WEXKVyK1vuuk8rSFP2iqXnlgrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.696.0.tgz",
+      "integrity": "sha512-T5s0IlBVX+gkb9g/I6CLt4yAZVzMSiGnbUqWihWsHvQR1WOoIcndQy/Oz/IJXT9T2ipoy7a80gzV6a5mglrioA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-endpoints": "^2.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.696.0.tgz",
+      "integrity": "sha512-Z5rVNDdmPOe6ELoM5AhF/ja5tSjbe6ctSctDPb0JdDf4dT0v2MfwhJKzXju2RzX8Es/77Glh7MlaXLE0kCB9+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.696.0.tgz",
+      "integrity": "sha512-KhKqcfyXIB0SCCt+qsu4eJjsfiOrNzK5dCV7RAW2YIpp+msxGUUX0NdRE9rkzjiv+3EMktgJm3eEIS+yxtlVdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.1.tgz",
+      "integrity": "sha512-bH7QW0+JdX0bPBadXt8GwMof/jz0H28I84hU1Uet9ISpzUqXqRQ3fEZJ+ANPOhzSEczYvANNl3uDQDYArSFDtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@aws-sdk/client-kms": {
       "version": "3.637.0",
       "license": "Apache-2.0",
@@ -384,6 +927,35 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.699.0.tgz",
+      "integrity": "sha512-iuaTnudaBfEET+o444sDwf71Awe6UiZfH+ipUPmswAi2jZDwdFF1nxMKDEKL8/LV5WpXsdKSfwgS0RQeupURew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.699.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.696.0.tgz",
+      "integrity": "sha512-9rTvUJIAj5d3//U5FDPWGJ1nFJLuWb30vugGOrWk7aNZ6y9tuA3PI7Cc9dP8WEXKVyK1vuuk8rSFP2iqXnlgrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.620.1",
       "license": "Apache-2.0",
@@ -503,6 +1075,525 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.699.0.tgz",
+      "integrity": "sha512-jBjOntl9zN9Nvb0jmbMGRbiTzemDz64ij7W6BDavxBJRZpRoNeN0QCz6RolkCyXnyUJjo5mF2unY2wnv00A+LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.699.0",
+        "@aws-sdk/client-sso": "3.696.0",
+        "@aws-sdk/client-sts": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.699.0",
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-ini": "3.699.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.696.0.tgz",
+      "integrity": "sha512-q5TTkd08JS0DOkHfUL853tuArf7NrPeqoS5UOvqJho8ibV9Ak/a/HO4kNvy9Nj3cib/toHYHsQIEtecUPSUUrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.699.0.tgz",
+      "integrity": "sha512-u8a1GorY5D1l+4FQAf4XBUC1T10/t7neuwT21r0ymrtMFSK2a9QqVHKMoLkvavAwyhJnARSBM9/UQC797PFOFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.699.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.699.0.tgz",
+      "integrity": "sha512-++lsn4x2YXsZPIzFVwv3fSUVM55ZT0WRFmPeNilYIhZClxHLmVAWKH4I55cY9ry60/aTKYjzOXkWwyBKGsGvQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.696.0.tgz",
+      "integrity": "sha512-3c9III1k03DgvRZWg8vhVmfIXPG6hAciN9MzQTzqGngzWAELZF/WONRTRQuDFixVtarQatmLHYVw/atGeA2Byw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/signature-v4": "^4.2.2",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-middleware": "^3.0.10",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.696.0.tgz",
+      "integrity": "sha512-T9iMFnJL7YTlESLpVFT3fg1Lkb1lD+oiaIC8KMpepb01gDUBIpj9+Y+pA/cgRWW0yRxmkDXNazAE2qQTVFGJzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.696.0.tgz",
+      "integrity": "sha512-GV6EbvPi2eq1+WgY/o2RFA3P7HGmnkIzCNmhwtALFlqMroLYWKE7PSeHw66Uh1dFQeVESn0/+hiUNhu1mB0emA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-stream": "^3.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.699.0.tgz",
+      "integrity": "sha512-dXmCqjJnKmG37Q+nLjPVu22mNkrGHY8hYoOt3Jo9R2zr5MYV7s/NHsCHr+7E+BZ+tfZYLRPeB1wkpTeHiEcdRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.699.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.699.0.tgz",
+      "integrity": "sha512-MmEmNDo1bBtTgRmdNfdQksXu4uXe66s0p1hi1YPrn1h59Q605eq/xiWbGL6/3KdkViH6eGUuABeV2ODld86ylg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-ini": "3.699.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.696.0.tgz",
+      "integrity": "sha512-mL1RcFDe9sfmyU5K1nuFkO8UiJXXxLX4JO1gVaDIOvPqwStpUAwi3A1BoeZhWZZNQsiKI810RnYGo0E0WB/hUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.699.0.tgz",
+      "integrity": "sha512-Ekp2cZG4pl9D8+uKWm4qO1xcm8/MeiI8f+dnlZm8aQzizeC+aXYy9GyoclSf6daK8KfRPiRfM7ZHBBL5dAfdMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.696.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/token-providers": "3.699.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.696.0.tgz",
+      "integrity": "sha512-XJ/CVlWChM0VCoc259vWguFUjJDn/QwDqHwbx+K9cg3v6yrqXfK5ai+p/6lx0nQpnk4JzPVeYYxWRpaTsGC9rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.696.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.696.0.tgz",
+      "integrity": "sha512-zELJp9Ta2zkX7ELggMN9qMCgekqZhFC5V2rOr4hJDEb/Tte7gpfKSObAnw/3AYiVqt36sjHKfdkoTsuwGdEoDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.696.0.tgz",
+      "integrity": "sha512-KhkHt+8AjCxcR/5Zp3++YPJPpFQzxpr+jmONiT/Jw2yqnSngZ0Yspm5wGoRx2hS1HJbyZNuaOWEGuJoxLeBKfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.696.0.tgz",
+      "integrity": "sha512-si/maV3Z0hH7qa99f9ru2xpS5HlfSVcasRlNUXKSDm611i7jFMWwGNLUOXFAOLhXotPX5G3Z6BLwL34oDeBMug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.696.0.tgz",
+      "integrity": "sha512-Lvyj8CTyxrHI6GHd2YVZKIRI5Fmnugt3cpJo0VrKKEgK5zMySwEZ1n4dqPK6czYRWKd5+WnYHYAuU+Wdk6Jsjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.696.0.tgz",
+      "integrity": "sha512-7EuH142lBXjI8yH6dVS/CZeiK/WZsmb/8zP6bQbVYpMrppSTgB3MzZZdxVZGzL5r8zPQOU10wLC4kIMy0qdBVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.699.0.tgz",
+      "integrity": "sha512-kuiEW9DWs7fNos/SM+y58HCPhcIzm1nEZLhe2/7/6+TvAYLuEWURYsbK48gzsxXlaJ2k/jGY3nIsA7RptbMOwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.699.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.696.0.tgz",
+      "integrity": "sha512-9rTvUJIAj5d3//U5FDPWGJ1nFJLuWb30vugGOrWk7aNZ6y9tuA3PI7Cc9dP8WEXKVyK1vuuk8rSFP2iqXnlgrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.696.0.tgz",
+      "integrity": "sha512-T5s0IlBVX+gkb9g/I6CLt4yAZVzMSiGnbUqWihWsHvQR1WOoIcndQy/Oz/IJXT9T2ipoy7a80gzV6a5mglrioA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-endpoints": "^2.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.696.0.tgz",
+      "integrity": "sha512-Z5rVNDdmPOe6ELoM5AhF/ja5tSjbe6ctSctDPb0JdDf4dT0v2MfwhJKzXju2RzX8Es/77Glh7MlaXLE0kCB9+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.696.0.tgz",
+      "integrity": "sha512-KhKqcfyXIB0SCCt+qsu4eJjsfiOrNzK5dCV7RAW2YIpp+msxGUUX0NdRE9rkzjiv+3EMktgJm3eEIS+yxtlVdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.1.tgz",
+      "integrity": "sha512-bH7QW0+JdX0bPBadXt8GwMof/jz0H28I84hU1Uet9ISpzUqXqRQ3fEZJ+ANPOhzSEczYvANNl3uDQDYArSFDtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
@@ -2432,10 +3523,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.1.1",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.8.tgz",
+      "integrity": "sha512-+3DOBcUn5/rVjlxGvUPKc416SExarAQ+Qe0bqk30YSUjbepwpS7QN0cyKUSifvLJhdMZ0WPzPP5ymut0oonrpQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2443,13 +3536,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.5",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.12.tgz",
+      "integrity": "sha512-YAJP9UJFZRZ8N+UruTeq78zkdjUHmzsY62J4qKWZ4SXB4QXJ/+680EfXXgkYA2xj77ooMqtUY9m406zGNqwivQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.10",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2457,17 +3552,17 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.4.0",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.4.tgz",
+      "integrity": "sha512-iFh2Ymn2sCziBRLPuOOxRPkuCx/2gBdXtBGuCUFLUe6bWYjKnhHyIPqGeNkLZ5Aco/5GjebRTBFiWID3sDbrKw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-stream": "^3.3.1",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -2476,13 +3571,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.2.0",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.7.tgz",
+      "integrity": "sha512-cEfbau+rrWF8ylkmmVAObOmjbTIzKyUC5TkBL58SbLywD0RCBC4JAUKbmtSm2w5KUJNRPGgpGFMvE2FKnuNlWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2501,10 +3598,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.10.tgz",
+      "integrity": "sha512-3zWGWCHI+FlJ5WJwx73Mw2llYR8aflVyZN5JhoqLxbdPZi6UyKSdCeXAWJw9ja22m6S6Tzz1KZ+kAaSwvydi0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -2514,10 +3613,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.10.tgz",
+      "integrity": "sha512-Lp2L65vFi+cj0vFMu2obpPW69DU+6O5g3086lmI4XcnRCG8PxvpWC7XyaVwJCxsZFzueHjXnrOH/E0pl0zikfA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       }
     },
@@ -2532,11 +3633,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.5",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.12.tgz",
+      "integrity": "sha512-1mDEXqzM20yywaMDuf5o9ue8OkJ373lSPbaSjyEvkWdqELhFMyNNgKGWL/rCSf4KME8B+HlHKuR8u9kRj8HzEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2544,15 +3647,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.1.0",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.4.tgz",
+      "integrity": "sha512-TybiW2LA3kYVd3e+lWhINVu1o26KJbBwOpADnf0L4x/35vLVica77XVR5hvV9+kWeTGeSJ3IHTcYxbRxlbwhsg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/core": "^2.5.4",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-middleware": "^3.0.10",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2560,16 +3666,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.15",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.28.tgz",
+      "integrity": "sha512-vK2eDfvIXG1U64FEUhYxoZ1JSj4XFbYWkK36iz02i3pFwWiDz1Q7jKhGTBCwx/7KqJNk4VS7d7cDLXFOvP7M+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/service-error-classification": "^3.0.10",
+        "@smithy/smithy-client": "^3.4.5",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -2578,10 +3686,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.10.tgz",
+      "integrity": "sha512-MnAuhh+dD14F428ubSJuRnmRsfOpxSzvRhaGVTvd/lrUDE3kxzCCmH8lnVTvoNQnV2BbJ4c15QwZ3UdQBtFNZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2589,10 +3699,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.10.tgz",
+      "integrity": "sha512-grCHyoiARDBBGPyw2BeicpjgpsDFWZZxptbVKb3CRd/ZA15F/T6rZjCCuBUjJwdck1nwUuIxYtsS4H9DDpbP5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2600,12 +3712,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.11.tgz",
+      "integrity": "sha512-URq3gT3RpDikh/8MBJUB+QGZzfS7Bm6TQTqoh4CqE8NBuyPkWa5eUXj0XFcFfeZVgg3WMh1u19iaXn8FvvXxZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/shared-ini-file-loader": "^3.1.11",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2613,13 +3727,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.1.4",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.1.tgz",
+      "integrity": "sha512-fr+UAOMGWh6bn4YSEezBCpJn9Ukp9oR4D32sCjCo7U81evE11YePOQ58ogzyfgmjIO79YeOdfXXqr0jyhPQeMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/abort-controller": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2627,10 +3743,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.1.3",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.10.tgz",
+      "integrity": "sha512-n1MJZGTorTH2DvyTVj+3wXnd4CzjJxyXeOgnTlgNVFxaaMeT4OteEp4QrzF8p9ee2yg42nvyVK6R/awLCakjeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2638,10 +3756,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.1.0",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.7.tgz",
+      "integrity": "sha512-FP2LepWD0eJeOTm0SjssPcgqAlDFzOmRXqXmGhfIM52G7Lrox/pcpQf6RP4F21k0+O12zaqQt5fCDOeBtqY6Cg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2649,10 +3769,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.10.tgz",
+      "integrity": "sha512-nT9CQF3EIJtIUepXQuBFb8dxJi3WVZS3XfuDksxSCSn+/CzZowRLdhDn+2acbBv8R6eaJqPupoI/aRFIImNVPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -2661,10 +3783,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.10.tgz",
+      "integrity": "sha512-Oa0XDcpo9SmjhiDD9ua2UyM3uU01ZTuIrNdZvzwUTykW1PM8o2yJvMh1Do1rY5sUQg4NDV70dMi0JhDx4GyxuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2672,20 +3796,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.10.tgz",
+      "integrity": "sha512-zHe642KCqDxXLuhs6xmHVgRwy078RfqxP2wRDpIyiF8EmsWXptMwnMwbVa50lw+WOGNrYm9zbaEg0oDe3PTtvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0"
+        "@smithy/types": "^3.7.1"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.11.tgz",
+      "integrity": "sha512-AUdrIZHFtUgmfSN4Gq9nHu3IkHMa1YDcN+s061Nfm+6pQ0mJy85YQDB0tZBCmls0Vuj22pLwDPmL92+Hvfwwlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2693,14 +3821,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "4.1.0",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.3.tgz",
+      "integrity": "sha512-pPSQQ2v2vu9vc8iew7sszLd0O09I5TRc5zhY71KA+Ao0xYazIG+uLeHbTJfIWGO3BGVLiXjUr3EEeCcEQLjpWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.10",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -2710,14 +3840,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.2.0",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.5.tgz",
+      "integrity": "sha512-k0sybYT9zlP79sIKd1XGm4TmK0AS1nA2bzDHXx7m0nGi3RQ8dxxQUs4CPkSmQTKAo+KF9aINU3KzpGIpV7UoMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.3",
+        "@smithy/core": "^2.5.4",
+        "@smithy/middleware-endpoint": "^3.2.4",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-stream": "^3.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2725,7 +3858,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.3.0",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.1.tgz",
+      "integrity": "sha512-XKLcLXZY7sUQgvvWyeaL/qwNPp6V3dWcUjqrQKjSb+tzYiCy340R/c64LV5j+Tnb2GhmunEX0eou+L+m2hJNYA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2735,11 +3870,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.10.tgz",
+      "integrity": "sha512-j90NUalTSBR2NaZTuruEgavSdh8MLirf58LoGSk4AtQfyIymogIhgnGUU2Mga2bkMkpSoC9gxb74xBXL5afKAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/querystring-parser": "^3.0.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       }
     },
@@ -2794,12 +3931,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.15",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.28.tgz",
+      "integrity": "sha512-6bzwAbZpHRFVJsOztmov5PGDmJYsbNSoIEfHSJJyFLzfBGCCChiO3od9k7E/TLgrCsIifdAbB9nqbVbyE7wRUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/smithy-client": "^3.4.5",
+        "@smithy/types": "^3.7.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -2808,15 +3947,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.15",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.28.tgz",
+      "integrity": "sha512-78ENJDorV1CjOQselGmm3+z7Yqjj5HWCbjzh0Ixuq736dh1oEnD9sAttSBNSLlpZsX8VQnmERqA2fEFlmqWn8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/credential-provider-imds": "^3.2.7",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/smithy-client": "^3.4.5",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2824,11 +3965,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.0.5",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.6.tgz",
+      "integrity": "sha512-mFV1t3ndBh0yZOJgWxO9J/4cHZVn5UG1D8DeCc6/echfNkeEJWu9LD7mgGH5fHrEdR7LDoWw7PQO6QiGpHXhgA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2846,10 +3989,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.10.tgz",
+      "integrity": "sha512-eJO+/+RsrG2RpmY68jZdwQtnfsxjmPxzMlQpnHKjFPwrYqvlcT+fHdT+ZVwcjlWSrByOhGr9Ff2GG17efc192A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2857,11 +4002,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.10.tgz",
+      "integrity": "sha512-1l4qatFp4PiU6j7UsbasUHL2VU023NRB/gfaa1M0rDqVrRN4g3mCArLRyH3OuktApA4ye+yjWQHjdziunw2eWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/service-error-classification": "^3.0.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2869,12 +4016,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.1.3",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.1.tgz",
+      "integrity": "sha512-Ff68R5lJh2zj+AUTvbAU/4yx+6QPRzg7+pI7M1FbtQHcRIp7xvguxVsQBKyB3fwiOwhAKu0lnNyYBaQfSW6TNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -2883,6 +4032,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.1.tgz",
+      "integrity": "sha512-bH7QW0+JdX0bPBadXt8GwMof/jz0H28I84hU1Uet9ISpzUqXqRQ3fEZJ+ANPOhzSEczYvANNl3uDQDYArSFDtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
@@ -9349,6 +10511,8 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.637.0",
+        "@aws-sdk/client-sts": "^3.699.0",
+        "@aws-sdk/credential-providers": "^3.699.0",
         "@azure/identity": "^4.4.1",
         "@azure/keyvault-keys": "^4.8.0",
         "@bufbuild/protobuf": "^2.0.0",
@@ -9418,6 +10582,497 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/client-sso": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.696.0.tgz",
+      "integrity": "sha512-q5TTkd08JS0DOkHfUL853tuArf7NrPeqoS5UOvqJho8ibV9Ak/a/HO4kNvy9Nj3cib/toHYHsQIEtecUPSUUrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.699.0.tgz",
+      "integrity": "sha512-u8a1GorY5D1l+4FQAf4XBUC1T10/t7neuwT21r0ymrtMFSK2a9QqVHKMoLkvavAwyhJnARSBM9/UQC797PFOFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.699.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/client-sts": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.699.0.tgz",
+      "integrity": "sha512-++lsn4x2YXsZPIzFVwv3fSUVM55ZT0WRFmPeNilYIhZClxHLmVAWKH4I55cY9ry60/aTKYjzOXkWwyBKGsGvQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/core": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.696.0.tgz",
+      "integrity": "sha512-3c9III1k03DgvRZWg8vhVmfIXPG6hAciN9MzQTzqGngzWAELZF/WONRTRQuDFixVtarQatmLHYVw/atGeA2Byw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/signature-v4": "^4.2.2",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-middleware": "^3.0.10",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.696.0.tgz",
+      "integrity": "sha512-T9iMFnJL7YTlESLpVFT3fg1Lkb1lD+oiaIC8KMpepb01gDUBIpj9+Y+pA/cgRWW0yRxmkDXNazAE2qQTVFGJzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.696.0.tgz",
+      "integrity": "sha512-GV6EbvPi2eq1+WgY/o2RFA3P7HGmnkIzCNmhwtALFlqMroLYWKE7PSeHw66Uh1dFQeVESn0/+hiUNhu1mB0emA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-stream": "^3.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.699.0.tgz",
+      "integrity": "sha512-dXmCqjJnKmG37Q+nLjPVu22mNkrGHY8hYoOt3Jo9R2zr5MYV7s/NHsCHr+7E+BZ+tfZYLRPeB1wkpTeHiEcdRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.699.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.699.0.tgz",
+      "integrity": "sha512-MmEmNDo1bBtTgRmdNfdQksXu4uXe66s0p1hi1YPrn1h59Q605eq/xiWbGL6/3KdkViH6eGUuABeV2ODld86ylg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-ini": "3.699.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.696.0.tgz",
+      "integrity": "sha512-mL1RcFDe9sfmyU5K1nuFkO8UiJXXxLX4JO1gVaDIOvPqwStpUAwi3A1BoeZhWZZNQsiKI810RnYGo0E0WB/hUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.699.0.tgz",
+      "integrity": "sha512-Ekp2cZG4pl9D8+uKWm4qO1xcm8/MeiI8f+dnlZm8aQzizeC+aXYy9GyoclSf6daK8KfRPiRfM7ZHBBL5dAfdMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.696.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/token-providers": "3.699.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.696.0.tgz",
+      "integrity": "sha512-XJ/CVlWChM0VCoc259vWguFUjJDn/QwDqHwbx+K9cg3v6yrqXfK5ai+p/6lx0nQpnk4JzPVeYYxWRpaTsGC9rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.696.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.696.0.tgz",
+      "integrity": "sha512-zELJp9Ta2zkX7ELggMN9qMCgekqZhFC5V2rOr4hJDEb/Tte7gpfKSObAnw/3AYiVqt36sjHKfdkoTsuwGdEoDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.696.0.tgz",
+      "integrity": "sha512-KhkHt+8AjCxcR/5Zp3++YPJPpFQzxpr+jmONiT/Jw2yqnSngZ0Yspm5wGoRx2hS1HJbyZNuaOWEGuJoxLeBKfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.696.0.tgz",
+      "integrity": "sha512-si/maV3Z0hH7qa99f9ru2xpS5HlfSVcasRlNUXKSDm611i7jFMWwGNLUOXFAOLhXotPX5G3Z6BLwL34oDeBMug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.696.0.tgz",
+      "integrity": "sha512-Lvyj8CTyxrHI6GHd2YVZKIRI5Fmnugt3cpJo0VrKKEgK5zMySwEZ1n4dqPK6czYRWKd5+WnYHYAuU+Wdk6Jsjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.696.0.tgz",
+      "integrity": "sha512-7EuH142lBXjI8yH6dVS/CZeiK/WZsmb/8zP6bQbVYpMrppSTgB3MzZZdxVZGzL5r8zPQOU10wLC4kIMy0qdBVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/token-providers": {
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.699.0.tgz",
+      "integrity": "sha512-kuiEW9DWs7fNos/SM+y58HCPhcIzm1nEZLhe2/7/6+TvAYLuEWURYsbK48gzsxXlaJ2k/jGY3nIsA7RptbMOwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.699.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/types": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.696.0.tgz",
+      "integrity": "sha512-9rTvUJIAj5d3//U5FDPWGJ1nFJLuWb30vugGOrWk7aNZ6y9tuA3PI7Cc9dP8WEXKVyK1vuuk8rSFP2iqXnlgrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.696.0.tgz",
+      "integrity": "sha512-T5s0IlBVX+gkb9g/I6CLt4yAZVzMSiGnbUqWihWsHvQR1WOoIcndQy/Oz/IJXT9T2ipoy7a80gzV6a5mglrioA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-endpoints": "^2.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.696.0.tgz",
+      "integrity": "sha512-Z5rVNDdmPOe6ELoM5AhF/ja5tSjbe6ctSctDPb0JdDf4dT0v2MfwhJKzXju2RzX8Es/77Glh7MlaXLE0kCB9+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "schemaregistry/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.696.0.tgz",
+      "integrity": "sha512-KhKqcfyXIB0SCCt+qsu4eJjsfiOrNzK5dCV7RAW2YIpp+msxGUUX0NdRE9rkzjiv+3EMktgJm3eEIS+yxtlVdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "schemaregistry/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.1.tgz",
+      "integrity": "sha512-bH7QW0+JdX0bPBadXt8GwMof/jz0H28I84hU1Uet9ISpzUqXqRQ3fEZJ+ANPOhzSEczYvANNl3uDQDYArSFDtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "schemaregistry/node_modules/uuid": {

--- a/schemaregistry/package.json
+++ b/schemaregistry/package.json
@@ -31,6 +31,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.637.0",
+    "@aws-sdk/client-sts": "^3.699.0",
+    "@aws-sdk/credential-providers": "^3.699.0",
     "@azure/identity": "^4.4.1",
     "@azure/keyvault-keys": "^4.8.0",
     "@bufbuild/protobuf": "^2.0.0",

--- a/schemaregistry/rules/encryption/awskms/aws-client.ts
+++ b/schemaregistry/rules/encryption/awskms/aws-client.ts
@@ -5,14 +5,14 @@ import {
   EncryptCommand,
   KMSClient
 } from '@aws-sdk/client-kms'
-import {AwsCredentialIdentity} from "@smithy/types";
+import {AwsCredentialIdentity, AwsCredentialIdentityProvider} from "@smithy/types";
 
 export class AwsKmsClient implements KmsClient {
 
   private kmsClient: KMSClient
   private keyId: string
 
-  constructor(keyUri: string, creds?: AwsCredentialIdentity) {
+  constructor(keyUri: string, creds?: AwsCredentialIdentity | AwsCredentialIdentityProvider) {
     if (!keyUri.startsWith(AwsKmsDriver.PREFIX)) {
       throw new Error(`key uri must start with ${AwsKmsDriver.PREFIX}`)
     }

--- a/schemaregistry/rules/encryption/awskms/aws-driver.ts
+++ b/schemaregistry/rules/encryption/awskms/aws-driver.ts
@@ -1,12 +1,16 @@
 import {KmsClient, KmsDriver, registerKmsDriver} from "../kms-registry";
 import {AwsKmsClient} from "./aws-client";
-import {AwsCredentialIdentity} from "@smithy/types";
+import {AwsCredentialIdentity, AwsCredentialIdentityProvider} from "@smithy/types";
+import {fromTemporaryCredentials} from '@aws-sdk/credential-providers'
 
 export class AwsKmsDriver implements KmsDriver {
 
   static PREFIX = 'aws-kms://'
   static ACCESS_KEY_ID = 'access.key.id'
   static SECRET_ACCESS_KEY = 'secret.access.key'
+  static ROLE_ARN = 'role.arn'
+  static ROLE_SESSION_NAME = 'role.session.name'
+  static ROLE_EXTERNAL_ID = 'role.external.id'
 
   /**
    * Register the AWS KMS driver with the KMS registry.
@@ -23,9 +27,29 @@ export class AwsKmsDriver implements KmsDriver {
     const uriPrefix = keyUrl != null ? keyUrl : AwsKmsDriver.PREFIX
     const key = config.get(AwsKmsDriver.ACCESS_KEY_ID)
     const secret = config.get(AwsKmsDriver.SECRET_ACCESS_KEY)
-    let creds: AwsCredentialIdentity | undefined
+    const roleArn = config.get(AwsKmsDriver.ROLE_ARN)
+    const roleSessionName = config.get(AwsKmsDriver.ROLE_SESSION_NAME)
+    const roleExternalId = config.get(AwsKmsDriver.ROLE_EXTERNAL_ID)
+    let creds: AwsCredentialIdentity | AwsCredentialIdentityProvider | undefined
     if (key != null && secret != null) {
       creds = {accessKeyId: key, secretAccessKey: secret}
+    }
+    if (roleArn != null) {
+      let keyId = uriPrefix.substring(AwsKmsDriver.PREFIX.length)
+      const tokens = keyId.split(':')
+      if (tokens.length < 4) {
+        throw new Error(`invalid key uri ${keyId}`)
+      }
+      const regionName = tokens[3]
+      creds = fromTemporaryCredentials({
+        masterCredentials: creds,
+        params: {
+          RoleArn: roleArn,
+          RoleSessionName: roleSessionName ?? "confluent-encrypt",
+          ExternalId: roleExternalId,
+        },
+        clientConfig: { region: regionName },
+      })
     }
     return new AwsKmsClient(uriPrefix, creds)
   }


### PR DESCRIPTION
Add AWS AssumeRole support to AWS KMS.  You can now specify a role arn, and optional role session name and optional role external id.