### PR TITLE
Ensure different key ids use different client instances

### DIFF
--- a/schemaregistry/rules/encryption/awskms/aws-client.ts
+++ b/schemaregistry/rules/encryption/awskms/aws-client.ts
@@ -10,12 +10,14 @@ import {AwsCredentialIdentity, AwsCredentialIdentityProvider} from "@smithy/type
 export class AwsKmsClient implements KmsClient {
 
   private kmsClient: KMSClient
+  private keyUri: string
   private keyId: string
 
   constructor(keyUri: string, creds?: AwsCredentialIdentity | AwsCredentialIdentityProvider) {
     if (!keyUri.startsWith(AwsKmsDriver.PREFIX)) {
       throw new Error(`key uri must start with ${AwsKmsDriver.PREFIX}`)
     }
+    this.keyUri = keyUri
     this.keyId = keyUri.substring(AwsKmsDriver.PREFIX.length)
     const tokens = this.keyId.split(':')
     if (tokens.length < 4) {
@@ -29,7 +31,7 @@ export class AwsKmsClient implements KmsClient {
   }
 
   supported(keyUri: string): boolean {
-    return keyUri.startsWith(AwsKmsDriver.PREFIX)
+    return this.keyUri === keyUri
   }
 
   async encrypt(plaintext: Buffer): Promise<Buffer> {

--- a/schemaregistry/rules/encryption/azurekms/azure-client.ts
+++ b/schemaregistry/rules/encryption/azurekms/azure-client.ts
@@ -7,18 +7,20 @@ export class AzureKmsClient implements KmsClient {
   private static ALGORITHM: EncryptionAlgorithm = 'RSA-OAEP-256'
 
   private kmsClient: CryptographyClient
+  private keyUri: string
   private keyId: string
 
   constructor(keyUri: string, creds: TokenCredential) {
     if (!keyUri.startsWith(AzureKmsDriver.PREFIX)) {
       throw new Error(`key uri must start with ${AzureKmsDriver.PREFIX}`)
     }
+    this.keyUri = keyUri
     this.keyId = keyUri.substring(AzureKmsDriver.PREFIX.length)
     this.kmsClient = new CryptographyClient(this.keyId, creds)
   }
 
   supported(keyUri: string): boolean {
-    return keyUri.startsWith(AzureKmsDriver.PREFIX)
+    return this.keyUri === keyUri
   }
 
   async encrypt(plaintext: Buffer): Promise<Buffer> {

--- a/schemaregistry/rules/encryption/gcpkms/gcp-client.ts
+++ b/schemaregistry/rules/encryption/gcpkms/gcp-client.ts
@@ -5,12 +5,14 @@ import {KeyManagementServiceClient} from "@google-cloud/kms";
 export class GcpKmsClient implements KmsClient {
 
   private kmsClient: KeyManagementServiceClient
+  private keyUri: string
   private keyId: string
 
   constructor(keyUri: string, creds?: GcpCredentials) {
     if (!keyUri.startsWith(GcpKmsDriver.PREFIX)) {
       throw new Error(`key uri must start with ${GcpKmsDriver.PREFIX}`)
     }
+    this.keyUri = keyUri
     this.keyId = keyUri.substring(GcpKmsDriver.PREFIX.length)
     this.kmsClient = creds != null
       ? new KeyManagementServiceClient({credentials: creds})
@@ -18,7 +20,7 @@ export class GcpKmsClient implements KmsClient {
   }
 
   supported(keyUri: string): boolean {
-    return keyUri.startsWith(GcpKmsDriver.PREFIX)
+    return this.keyUri === keyUri
   }
 
   async encrypt(plaintext: Buffer): Promise<Buffer> {

--- a/schemaregistry/rules/encryption/hcvault/hcvault-client.ts
+++ b/schemaregistry/rules/encryption/hcvault/hcvault-client.ts
@@ -5,6 +5,7 @@ import NodeVault from "node-vault";
 export class HcVaultClient implements KmsClient {
 
   private kmsClient: NodeVault.client
+  private keyUri: string
   private keyId: string
   private keyName: string
 
@@ -12,6 +13,7 @@ export class HcVaultClient implements KmsClient {
     if (!keyUri.startsWith(HcVaultDriver.PREFIX)) {
       throw new Error(`key uri must start with ${HcVaultDriver.PREFIX}`)
     }
+    this.keyUri = keyUri
     this.keyId = keyUri.substring(HcVaultDriver.PREFIX.length)
     let url = new URL(this.keyId)
     let parts = url.pathname.split('/')
@@ -28,7 +30,7 @@ export class HcVaultClient implements KmsClient {
   }
 
   supported(keyUri: string): boolean {
-    return keyUri.startsWith(HcVaultDriver.PREFIX)
+    return this.keyUri === keyUri
   }
 
   async encrypt(plaintext: Buffer): Promise<Buffer> {


### PR DESCRIPTION
Ensure different key ids use different client instances.
This was a bug caused by an incorrect port of the corresponding Java code