### PR TITLE
Add singleton principle to RestService

### DIFF
--- a/schemaregistry/package.json
+++ b/schemaregistry/package.json
@@ -59,6 +59,7 @@
   "scripts": {
     "lint": "make lint",
     "test": "make test",
+    "integtest": "make integtest",
     "build": "rm -rf ./dist && tsc -p tsconfig-build.json"
   },
   "keywords": [

--- a/schemaregistry/rules/encryption/dekregistry/dekregistry-client.ts
+++ b/schemaregistry/rules/encryption/dekregistry/dekregistry-client.ts
@@ -70,7 +70,7 @@ class DekRegistryClient implements DekClient {
     };
 
 
-    this.restService = new RestService(config.baseURLs, config.isForward, config.createAxiosDefaults,
+    this.restService = RestService.getInstance(config.baseURLs, config.isForward, config.createAxiosDefaults,
       config.basicAuthCredentials, config.bearerAuthCredentials,
       config.maxRetries, config.retriesWaitMs, config.retriesMaxWaitMs);
     this.kekCache = new LRUCache<string, Kek>(cacheOptions);

--- a/schemaregistry/schemaregistry-client.ts
+++ b/schemaregistry/schemaregistry-client.ts
@@ -201,7 +201,7 @@ export class SchemaRegistryClient implements Client {
       ...(config.cacheLatestTtlSecs !== undefined && { ttl: config.cacheLatestTtlSecs * 1000 })
     };
 
-    this.restService = new RestService(config.baseURLs, config.isForward, config.createAxiosDefaults,
+    this.restService = RestService.getInstance(config.baseURLs, config.isForward, config.createAxiosDefaults,
       config.basicAuthCredentials, config.bearerAuthCredentials,
       config.maxRetries, config.retriesWaitMs, config.retriesMaxWaitMs);
 


### PR DESCRIPTION
RestService would be created multiple times for both the DekRegistry and SchemaRegistry clients. This would specifically be an issue as the OAuth client would also be created twice, with two tokens to manage.