### PR TITLE
Re-setup docs generation from code

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,3 +17,4 @@ deps/librdkafka/config.h
 /bench
 /ci
 /proto
+/docs

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -87,7 +87,7 @@ blocks:
             - npm run install-from-source
             - make test
 
-  - name: "Linux amd64: Build, test, lint"
+  - name: "Linux amd64: Build, test, lint, docs"
     dependencies: [ ]
     task:
       agent:
@@ -110,6 +110,9 @@ blocks:
         - name: "ESLint"
           commands:
             - npx eslint lib/kafkajs
+        - name: "Docs"
+          commands:
+            - make docs
 
   - name: "Linux amd64: Performance"
     dependencies: [ ]

--- a/Makefile
+++ b/Makefile
@@ -74,14 +74,7 @@ define release
 endef
 
 docs: node_modules/.dirstamp
-	@rm -rf docs
-	@./node_modules/jsdoc/jsdoc.js --debug --destination docs \
-		--recurse -R ./README.md \
-		-c ./jsdoc.conf \
-		--tutorials examples/ ./lib
-
-gh-pages: node_modules/.dirstamp
-	@./make_docs.sh
+	@./util/generate-docs.sh
 
 release-patch:
 	@$(call release,patch)

--- a/jsdoc.conf
+++ b/jsdoc.conf
@@ -1,8 +1,13 @@
 {
-    "plugins": [],
+    "plugins": [
+        "plugins/markdown"
+    ],
     "recurseDepth": 10,
     "source": {
-        "includePattern": ".+\\.js(doc|x)?$"
+        "include": ["lib"],
+        "exclude": ["lib/kafkajs/_common.js"],
+        "includePattern": ".+\\.js?$",
+        "excludePattern": ""
     },
     "sourceType": "module",
     "tags": {
@@ -10,7 +15,9 @@
         "dictionaries": ["jsdoc","closure"]
     },
     "templates": {
-        "cleverLinks": false,
-        "monospaceLinks": false
+        "default": {
+            "useLongnameInNav": true,
+            "outputSourceFiles": false
+        }
     }
 }

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -13,16 +13,29 @@
  * hardcoded list.
  * New additions won't be automatically added to this list.
  */
-const ConsumerGroupStates = Object.seal({
+
+/**
+ * A list of consumer group states.
+ * @enum {number}
+ * @readonly
+ * @memberof RdKafka
+ */
+const ConsumerGroupStates = {
   UNKNOWN: 0,
   PREPARING_REBALANCE: 1,
   COMPLETING_REBALANCE: 2,
   STABLE: 3,
   DEAD: 4,
   EMPTY: 5,
-});
+};
 
-const AclOperationTypes = Object.seal({
+/**
+ * A list of ACL operation types.
+ * @enum {number}
+ * @readonly
+ * @memberof RdKafka
+ */
+const AclOperationTypes = {
   UNKNOWN: 0,
   ANY: 1,
   ALL: 2,
@@ -36,13 +49,13 @@ const AclOperationTypes = Object.seal({
   DESCRIBE_CONFIGS: 10,
   ALTER_CONFIGS: 11,
   IDEMPOTENT_WRITE: 12,
-});
+};
 
 module.exports = {
   create: createAdminClient,
   createFrom: createAdminClientFrom,
-  ConsumerGroupStates,
-  AclOperationTypes,
+  ConsumerGroupStates: Object.freeze(ConsumerGroupStates),
+  AclOperationTypes: Object.freeze(AclOperationTypes),
 };
 
 var Client = require('./client');
@@ -54,14 +67,15 @@ var { shallowCopy } = require('./util');
 util.inherits(AdminClient, Client);
 
 /**
- * Create a new AdminClient for making topics, partitions, and more.
+ * Create a new AdminClient using the provided configuration.
  *
  * This is a factory method because it immediately starts an
  * active handle with the brokers.
  *
- * @param {object} conf - Key value pairs to configure the admin client
- * @param {object} eventHandlers - optional key value pairs of event handlers to attach to the client
- *
+ * @param {object} conf - Key value pairs to configure the admin client.
+ * @param {object?} eventHandlers - Optional key value pairs of event handlers to attach to the client.
+ * @memberof RdKafka
+ * @alias RdKafka.AdminClient.create
  */
 function createAdminClient(conf, eventHandlers) {
   var client = new AdminClient(conf);
@@ -85,11 +99,14 @@ function createAdminClient(conf, eventHandlers) {
  * This is a factory method because it immediately starts an
  * active handle with the brokers.
  *
- * The producer or consumer being used must be connected.
- * The client can only be used while the producer or consumer is connected.
+ * The producer or consumer being used must be connected before creating the admin client,
+ * and the admin client can only be used while the producer or consumer is connected.
+ *
  * Logging and other events from this client will be emitted on the producer or consumer.
- * @param {import('../types/rdkafka').Producer | import('../types/rdkafka').KafkaConsumer} existingClient a producer or consumer to create the admin client from
- * @param {object} eventHandlers optional key value pairs of event handlers to attach to the client
+ * @param {RdKafka.Producer | RdKafka.KafkaConsumer} existingClient - A producer or consumer to create the admin client from.
+ * @param {object?} eventHandlers - Optional key value pairs of event handlers to attach to the client.
+ * @memberof RdKafka
+ * @alias RdKafka.AdminClient.createFrom
  */
 function createAdminClientFrom(existingClient, eventHandlers) {
   var client = new AdminClient(null, existingClient);
@@ -107,25 +124,25 @@ function createAdminClientFrom(existingClient, eventHandlers) {
 }
 
 /**
- * AdminClient class for administering Kafka
+ * AdminClient class for administering Kafka clusters (promise-based, async API).
  *
  * This client is the way you can interface with the Kafka Admin APIs.
  * This class should not be made using the constructor, but instead
- * should be made using the factory method.
- *
- * <code>
- * var client = AdminClient.create({ ... }); // From configuration
- * var client = AdminClient.createFrom(existingClient); // From existing producer or consumer
- * </code>
+ * should be made using the factory methods (see {@link RdKafka.AdminClient.create}
+ * and {@link RdKafka.AdminClient.createFrom}).
  *
  * Once you instantiate this object, it will have a handle to the kafka broker.
  * Unlike the other confluent-kafka-javascript classes, this class does not ensure that
  * it is connected to the upstream broker. Instead, making an action will
  * validate that.
  *
- * @param {object} conf - Key value pairs to configure the admin client
- * topic configuration
- * @param {import('../types/rdkafka').Producer | import('../types/rdkafka').KafkaConsumer | null} existingClient
+ * @example
+ * var client = AdminClient.create({ ... }); // From configuration
+ * var client = AdminClient.createFrom(existingClient); // From existing producer or consumer
+ *
+ * @param {object|null} conf - Key value pairs to configure the admin client
+ * @param {RdKafka.Producer | RdKafka.KafkaConsumer | null} existingClient - An existing producer or consumer to create the admin client from (optional).
+ * @memberof RdKafka
  * @constructor
  */
 function AdminClient(conf, existingClient) {
@@ -156,6 +173,7 @@ function AdminClient(conf, existingClient) {
  * need to be called outside.
  *
  * Unlike the other connect methods, this one is synchronous.
+ * @private
  */
 AdminClient.prototype.connect = function () {
   if (!this._hasUnderlyingClient) {
@@ -172,7 +190,7 @@ AdminClient.prototype.connect = function () {
  * Disconnect the admin client.
  *
  * This is a synchronous method, but all it does is clean up
- * some memory and shut some threads down
+ * some memory and shut some threads down.
  */
 AdminClient.prototype.disconnect = function () {
   if (this._hasUnderlyingClient) {
@@ -190,9 +208,13 @@ AdminClient.prototype.disconnect = function () {
 /**
  * Create a topic with a given config.
  *
- * @param {NewTopic} topic - Topic to create.
- * @param {number} timeout - Number of milliseconds to wait while trying to create the topic.
- * @param {function} cb - The callback to be executed when finished
+ * @param {object} topic - Topic to create.
+ * @param {string} topic.topic - The name of the topic to create.
+ * @param {number} topic.num_partitions - The number of partitions for the topic.
+ * @param {number} topic.replication_factor - The replication factor for the topic.
+ * @param {object?} topic.config - The topic configuration. The keys of this object denote the keys of the configuration.
+ * @param {number?} timeout - Number of milliseconds to wait while trying to create the topic. Set to 5000 by default.
+ * @param {function} cb - The callback to be executed when finished.
  */
 AdminClient.prototype.createTopic = function (topic, timeout, cb) {
   if (!this._isConnected) {
@@ -226,8 +248,8 @@ AdminClient.prototype.createTopic = function (topic, timeout, cb) {
  * Delete a topic.
  *
  * @param {string} topic - The topic to delete, by name.
- * @param {number} timeout - Number of milliseconds to wait while trying to delete the topic.
- * @param {function} cb - The callback to be executed when finished
+ * @param {number?} timeout - Number of milliseconds to wait while trying to delete the topic. Set to 5000 by default.
+ * @param {function} cb - The callback to be executed when finished.
  */
 AdminClient.prototype.deleteTopic = function (topic, timeout, cb) {
   if (!this._isConnected) {
@@ -262,9 +284,9 @@ AdminClient.prototype.deleteTopic = function (topic, timeout, cb) {
  *
  * @param {string} topic - The topic to add partitions to, by name.
  * @param {number} totalPartitions - The total number of partitions the topic should have
- *                                   after the request
- * @param {number} timeout - Number of milliseconds to wait while trying to create the partitions.
- * @param {function} cb - The callback to be executed when finished
+ *                                   after the request.
+ * @param {number?} timeout - Number of milliseconds to wait while trying to create the partitions. Set to 5000 by default.
+ * @param {function} cb - The callback to be executed when finished.
  */
 AdminClient.prototype.createPartitions = function (topic, totalPartitions, timeout, cb) {
   if (!this._isConnected) {
@@ -296,16 +318,17 @@ AdminClient.prototype.createPartitions = function (topic, totalPartitions, timeo
 
 /**
  * List consumer groups.
+ *
  * @param {any} options
  * @param {number?} options.timeout - The request timeout in milliseconds.
- *                                    May be unset (default: 5000)
- * @param {import("../").ConsumerGroupStates[]?} options.matchConsumerGroupStates -
+ *                                    May be unset (default: 5000).
+ * @param {Array<RdKafka.ConsumerGroupStates>?} options.matchConsumerGroupStates -
  *        A list of consumer group states to match. May be unset, fetches all states (default: unset).
  * @param {function} cb - The callback to be executed when finished.
- *
- * Valid ways to call this function:
- * listGroups(cb)
- * listGroups(options, cb)
+ * @example
+ * // Valid ways to call this function:
+ * listGroups(cb);
+ * listGroups(options, cb);
  */
 AdminClient.prototype.listGroups = function (options, cb) {
   if (!this._isConnected) {
@@ -337,14 +360,15 @@ AdminClient.prototype.listGroups = function (options, cb) {
 
 /**
  * Describe consumer groups.
- * @param {string[]} groups - The names of the groups to describe.
- * @param {any?} options
+ * @param {Array<string>} groups - The names of the groups to describe.
+ * @param {object} options
  * @param {number?} options.timeout - The request timeout in milliseconds.
- *                                    May be unset (default: 5000)
+ *                                    May be unset (default: 5000).
  * @param {boolean?} options.includeAuthorizedOperations - If true, include operations allowed on the group by the calling client (default: false).
  * @param {function} cb - The callback to be executed when finished.
  *
- * Valid ways to call this function:
+ * @example
+ * // Valid ways to call this function:
  * describeGroups(groups, cb)
  * describeGroups(groups, options, cb)
  */
@@ -379,12 +403,13 @@ AdminClient.prototype.describeGroups = function (groups, options, cb) {
 /**
  * Delete consumer groups.
  * @param {string[]} groups - The names of the groups to delete.
- * @param {any?} options
+ * @param {object} options
  * @param {number?} options.timeout - The request timeout in milliseconds.
- *                                    May be unset (default: 5000)
+ *                                    May be unset (default: 5000).
  * @param {function} cb - The callback to be executed when finished.
  *
- * Valid ways to call this function:
+ * @example
+ * // Valid ways to call this function:
  * deleteGroups(groups, cb)
  * deleteGroups(groups, options, cb)
  */
@@ -419,12 +444,13 @@ AdminClient.prototype.deleteGroups = function (groups, options, cb) {
 /**
  * List topics.
  *
- * @param {any?} options
+ * @param {object} options
  * @param {number?} options.timeout - The request timeout in milliseconds.
- *                                    May be unset (default: 5000)
+ *                                    May be unset (default: 5000).
  * @param {function} cb - The callback to be executed when finished.
  *
- * Valid ways to call this function:
+ * @example
+ * // Valid ways to call this function:
  * listTopics(cb)
  * listTopics(options, cb)
  */
@@ -475,13 +501,14 @@ AdminClient.prototype.listTopics = function (options, cb) {
 /**
  * List offsets for topic partition(s) for consumer group(s).
  *
- * @param {import("../../types/rdkafka").ListGroupOffsets} listGroupOffsets - The list of groupId, partitions to fetch offsets for.
- *                                                                            If partitions is null, list offsets for all partitions
- *                                                                            in the group.
+ * @param {{groupId: string, partitions: Array<number>|null}} listGroupOffsets
+ *  The list of groupId, partitions to fetch offsets for. If partitions is null, list offsets for all partitions
+ *  in the group.
+ * @param {object} options
  * @param {number?} options.timeout - The request timeout in milliseconds.
- *                                    May be unset (default: 5000)
+ *                                    May be unset (default: 5000).
  * @param {boolean?} options.requireStableOffsets - Whether broker should return stable offsets
- *                                                  (transaction-committed). (default: false)
+ *                                                  (transaction-committed). (default: false).
  *
  * @param {function} cb - The callback to be executed when finished.
  */
@@ -523,15 +550,15 @@ AdminClient.prototype.listConsumerGroupOffsets = function (listGroupOffsets, opt
 
 /**
  * Deletes records (messages) in topic partitions older than the offsets provided.
- * Provide Topic.OFFSET_END or -1 as offset to delete all records.
+ * Provide Topic.OFFSET_END or -1 as the offset to delete all records.
  *
- * @param {import("../../types/rdkafka").TopicPartitionOffset[]} delRecords - The list of topic partitions and
- *                                                                            offsets to delete records up to.
+ * @param {Array<{topic: string, partition: number, offset: number}>} delRecords
+ * The list of topic partitions and offsets to delete records up to.
+ * @param {object} options
  * @param {number?} options.operationTimeout - The operation timeout in milliseconds.
- *                                             May be unset (default: 60000)
+ *                                             May be unset (default: 60000).
  * @param {number?} options.timeout - The request timeout in milliseconds.
- *                                    May be unset (default: 5000)
- *
+ *                                    May be unset (default: 5000).
  * @param {function} cb - The callback to be executed when finished.
  */
 AdminClient.prototype.deleteRecords = function (delRecords, options, cb) {
@@ -570,13 +597,14 @@ AdminClient.prototype.deleteRecords = function (delRecords, options, cb) {
 };
 
 /**
- * Describe Topics.
+ * Describe topics.
  *
- * @param {string[]} topics - The names of the topics to describe.
+ * @param {Array<string>} topics - The names of the topics to describe.
+ * @param {object} options
  * @param {number?} options.timeout - The request timeout in milliseconds.
- *                                    May be unset (default: 5000)
+ *                                    May be unset (default: 5000).
  * @param {boolean?} options.includeAuthorizedOperations - If true, include operations allowed on the topic by the calling client.
- *                                                         (default: false)
+ *                                                         (default: false).
  * @param {function} cb - The callback to be executed when finished.
  */
 AdminClient.prototype.describeTopics = function (topics, options, cb) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -21,7 +21,7 @@ var LibrdKafkaError = require('./error');
 util.inherits(Client, Emitter);
 
 /**
- * Base class for Consumer and Producer
+ * Base class for Consumer and Producer.
  *
  * This should not be created independently, but rather is
  * the base class on which both producer and consumer
@@ -31,10 +31,12 @@ util.inherits(Client, Emitter);
  * @param {function} SubClientType - The function representing the subclient
  * type. In C++ land this needs to be a class that inherits from Connection.
  * @param {object} topicConf - Topic configuration in key value pairs
- * @param {object} existingClient - a producer or a consumer to derive this client from.
- *                                  only used by the AdminClient. Must be connected.
+ * @param {object?} existingClient - a producer or a consumer to derive this client from.
+ *                                   Only used by the AdminClient. Must be connected.
  * @constructor
  * @extends Emitter
+ * @memberof RdKafka
+ * @package
  */
 function Client(globalConf, SubClientType, topicConf, existingClient) {
   if (!(this instanceof Client)) {
@@ -187,7 +189,8 @@ function Client(globalConf, SubClientType, topicConf, existingClient) {
    * Metadata object. Starts out empty but will be filled with information after
    * the initial connect.
    *
-   * @type {Client~Metadata}
+   * @type {RdKafka.Client~Metadata}
+   * @private
    */
   this._metadata = {};
 
@@ -215,13 +218,14 @@ function Client(globalConf, SubClientType, topicConf, existingClient) {
  *
  * Connects to a broker by establishing the client and fetches its metadata.
  *
- * @param {object} metadataOptions - Options to be sent to the metadata.
+ * @param {object?} metadataOptions - Options to be sent to the metadata.
  * @param {string} metadataOptions.topic - Topic to fetch metadata for. Empty string is treated as empty.
  * @param {boolean} metadataOptions.allTopics - Fetch metadata for all topics, not just the ones we know about.
  * @param {int} metadataOptions.timeout - The timeout, in ms, to allow for fetching metadata. Defaults to 30000ms
- * @param  {Client~connectionCallback} cb - Callback that indicates we are
+ * @param  {RdKafka.Client~connectionCallback?} cb - Callback that indicates we are
  * done connecting.
- * @return {Client} - Returns itself.
+ * @fires RdKafka.Client#ready
+ * @return {RdKafka.Client} - Returns itself.
  */
 Client.prototype.connect = function(metadataOptions, cb) {
   if (this._hasUnderlyingClient) {
@@ -312,9 +316,9 @@ Client.prototype.connect = function(metadataOptions, cb) {
       /**
        * Ready event. Called when the Client connects successfully
        *
-       * @event Client#ready
+       * @event RdKafka.Client#ready
        * @type {object}
-       * @property {string} name - the name of the broker.
+       * @property {string} name - the name of the client.
        */
       self.emit('ready', info, metadata);
       next(null, metadata); return;
@@ -331,7 +335,7 @@ Client.prototype.connect = function(metadataOptions, cb) {
  * Get the native Kafka client.
  *
  * You probably shouldn't use this, but if you want to execute methods directly
- * on the c++ wrapper you can do it here.
+ * on the C++ wrapper you can do it here.
  *
  * @see connection.cc
  * @return {Connection} - The native Kafka client.
@@ -364,7 +368,7 @@ Client.prototype.isConnected = function() {
 /**
  * Get the last error emitted if it exists.
  *
- * @return {LibrdKafkaError} - Returns the LibrdKafkaError or null if
+ * @return {LibrdKafkaError?} - Returns the LibrdKafkaError or null if
  * one hasn't been thrown.
  */
 Client.prototype.getLastError = function() {
@@ -380,8 +384,8 @@ Client.prototype.getLastError = function() {
  *
  * It will also emit the disconnected event.
  *
- * @fires Client#disconnected
- * @return {function} - Callback to call when disconnection is complete.
+ * @fires RdKafka.Client#disconnected
+ * @param {function} cb - Callback to call when disconnection is complete.
  */
 Client.prototype.disconnect = function(cb) {
   if (this._hasUnderlyingClient) {
@@ -403,14 +407,15 @@ Client.prototype.disconnect = function(cb) {
 
       // Broadcast metrics. Gives people one last chance to do something with them
       self._isDisconnecting = false;
+      var metricsCopy = Object.assign({}, self.metrics);
       /**
        * Disconnect event. Called after disconnection is finished.
        *
-       * @event Client#disconnected
+       * @event RdKafka.Client#disconnected
        * @type {object}
        * @property {date} connectionOpened - when the connection was opened.
+       * @memberof RdKafka
        */
-      var metricsCopy = Object.assign({}, self.metrics);
       self.emit('disconnected', metricsCopy);
       if (cb) {
         cb(null, metricsCopy);
@@ -426,22 +431,25 @@ Client.prototype.disconnect = function(cb) {
 /**
  * Get client metadata.
  *
- * Note: using a <code>metadataOptions.topic</code> parameter has a potential side-effect.
+ * Use {@link RdKafka.AdminClient#describeTopics} instead for fetching metadata for specific
+ * topics.
+ *
+ * Note: using a `metadataOptions.topic` parameter has a potential side-effect.
  * A Topic object will be created, if it did not exist yet, with default options
  * and it will be cached by librdkafka.
  *
- * A subsequent call to create the topic object with specific options (e.g. <code>acks</code>) will return
+ * A subsequent call to create the topic object with specific options (e.g. `acks`) will return
  * the previous instance and the specific options will be silently ignored.
  *
  * To avoid this side effect, the topic object can be created with the expected options before requesting metadata,
- * or the metadata request can be performed for all topics (by omitting <code>metadataOptions.topic</code>).
+ * or the metadata request can be performed for all topics (by omitting `metadataOptions.topic`).
  *
  * @param {object} metadataOptions - Metadata options to pass to the client.
  * @param {string} metadataOptions.topic - Topic string for which to fetch
  * metadata
  * @param {number} metadataOptions.timeout - Max time, in ms, to try to fetch
  * metadata before timing out. Defaults to 3000.
- * @param {Client~metadataCallback} cb - Callback to fire with the metadata.
+ * @param {function} cb - Callback to fire with the metadata.
  */
 Client.prototype.getMetadata = function(metadataOptions, cb) {
   if (!this.isConnected()) {
@@ -478,7 +486,7 @@ Client.prototype.getMetadata = function(metadataOptions, cb) {
  * @param {string} topic - Topic to recieve offsets from.
  * @param {number} partition - Partition of the provided topic to recieve offsets from
  * @param {number} timeout - Number of ms to wait to recieve a response.
- * @param {Client~watermarkOffsetsCallback} cb - Callback to fire with the offsets.
+ * @param {RdKafka.ClientClient~watermarkOffsetsCallback} cb - Callback to fire with the offsets.
  */
 Client.prototype.queryWatermarkOffsets = function(topic, partition, timeout, cb) {
   if (!this.isConnected()) {
@@ -522,7 +530,7 @@ Client.prototype.queryWatermarkOffsets = function(topic, partition, timeout, cb)
  *                                     should instead refer to a timestamp you want
  *                                     offsets for
  * @param {number} timeout - Number of ms to wait to recieve a response.
- * @param {Client~offsetsForTimesCallback} cb - Callback to fire with the filled in offsets.
+ * @param {RdKafka.Client~offsetsForTimesCallback} cb - Callback to fire with the filled in offsets.
  */
 Client.prototype.offsetsForTimes = function(toppars, timeout, cb) {
   if (!this.isConnected()) {
@@ -559,10 +567,10 @@ Client.prototype.offsetsForTimes = function(toppars, timeout, cb) {
 
 /**
  * Change SASL credentials to be sent on the next authentication attempt.
- *
+*
+ * Only applicable if SASL authentication is being used.
  * @param {string} username
  * @param {string} password
- * @note Only applicable if SASL authentication is being used.
  */
 Client.prototype.setSaslCredentials = function(username, password) {
   if (!this.isConnected()) {
@@ -606,54 +614,54 @@ Client.prototype._errorWrap = function(errorCode, intIsError) {
  * This callback is used to pass metadata or an error after a successful
  * connection
  *
- * @callback Client~connectionCallback
+ * @callback RdKafka.Client~connectionCallback
  * @param {Error} err - An error, if one occurred while connecting.
- * @param {Client~Metadata} metadata - Metadata object.
+ * @param {RdKafka.Client~Metadata} metadata - Metadata object.
  */
 
  /**
   * This callback is used to pass offsets or an error after a successful
   * query
   *
-  * @callback Client~watermarkOffsetsCallback
+  * @callback RdKafka.Client~watermarkOffsetsCallback
   * @param {Error} err - An error, if one occurred while connecting.
-  * @param {Client~watermarkOffsets} offsets - Watermark offsets
+  * @param {RdKafka.Client~watermarkOffsets} offsets - Watermark offsets
   */
 
   /**
    * This callback is used to pass toppars or an error after a successful
    * times query
    *
-   * @callback Client~offsetsForTimesCallback
+   * @callback RdKafka.Client~offsetsForTimesCallback
    * @param {Error} err - An error, if one occurred while connecting.
    * @param {TopicPartition[]} toppars - Topic partitions with offsets filled in
    */
 
 /**
- * @typedef {object} Client~watermarkOffsets
+ * @typedef {object} RdKafka.Client~watermarkOffsets
  * @property {number} high - High (newest/end) offset
  * @property {number} low - Low (oldest/beginning) offset
  */
 
 /**
- * @typedef {object} Client~MetadataBroker
+ * @typedef {object} RdKafka.Client~MetadataBroker
  * @property {number} id - Broker ID
  * @property {string} host - Broker host
  * @property {number} port - Broker port.
  */
 
 /**
- * @typedef {object} Client~MetadataTopic
+ * @typedef {object} RdKafka.Client~MetadataTopic
  * @property {string} name - Topic name
- * @property {Client~MetadataPartition[]} partitions - Array of partitions
+ * @property {RdKafka.Client~MetadataPartition[]} partitions - Array of partitions
  */
 
 /**
- * @typedef {object} Client~MetadataPartition
+ * @typedef {object} RdKafka.Client~MetadataPartition
  * @property {number} id - Partition id
  * @property {number} leader - Broker ID for the partition leader
  * @property {number[]} replicas - Array of replica IDs
- * @property {number[]} isrs - Arrqay of ISRS ids
+ * @property {number[]} isrs - Array of ISRS ids
 */
 
 /**
@@ -661,11 +669,11 @@ Client.prototype._errorWrap = function(errorCode, intIsError) {
  *
  * This is the representation of Kafka metadata in JavaScript.
  *
- * @typedef {object} Client~Metadata
+ * @typedef {object} RdKafka.Client~Metadata
  * @property {number} orig_broker_id - The broker ID of the original bootstrap
  * broker.
  * @property {string} orig_broker_name - The name of the original bootstrap
  * broker.
- * @property {Client~MetadataBroker[]} brokers - An array of broker objects
- * @property {Client~MetadataTopic[]} topics - An array of topics.
+ * @property {RdKafka.Client~MetadataBroker[]} brokers - An array of broker objects
+ * @property {RdKafka.Client~MetadataTopic[]} topics - An array of topics.
  */

--- a/lib/error.js
+++ b/lib/error.js
@@ -26,6 +26,7 @@ LibrdKafkaError.wrap = errorWrap;
  * @readonly
  * @enum {number}
  * @constant
+ * @memberof RdKafka
  */
 // ====== Generated from librdkafka 2.6.1 file src-cpp/rdkafkacpp.h ======
 LibrdKafkaError.codes = {
@@ -389,6 +390,8 @@ LibrdKafkaError.codes = {
  * @property {number} code - The error code.
  * @property {string} origin - The origin, whether it is local or remote
  * @constructor
+ * @see {@link RdKafka.LibrdKafkaError.codes} For a list of error codes that can be returned, to compare against while handling this error.
+ * @memberof RdKafka
  */
 function LibrdKafkaError(e) {
   if (!(this instanceof LibrdKafkaError)) {

--- a/lib/kafka-consumer-stream.js
+++ b/lib/kafka-consumer-stream.js
@@ -22,7 +22,8 @@ util.inherits(KafkaConsumerStream, Readable);
  * This class is used to read data off of Kafka in a streaming way. It is
  * useful if you'd like to have a way to pipe Kafka into other systems. You
  * should generally not make this class yourself, as it is not even exposed
- * as part of module.exports. Instead, you should KafkaConsumer.createReadStream.
+ * as part of module.exports. Instead, you should use
+ * {@link RdKafka.KafkaConsumer.createReadStream}.
  *
  * The stream implementation is slower than the continuous subscribe callback.
  * If you don't care so much about backpressure and would rather squeeze
@@ -32,15 +33,27 @@ util.inherits(KafkaConsumerStream, Readable);
  * The stream detects if Kafka is already connected. If it is, it will begin
  * reading. If it is not, it will connect and read when it is ready.
  *
- * This stream operates in objectMode. It streams {Consumer~Message}
+ * This stream operates in objectMode. It streams {@link RdKafka.KafkaConsumer~Message}.
  *
- * @param {Consumer} consumer - The Kafka Consumer object.
+ * @param {RdKafka.KafkaConsumer} consumer - The Kafka Consumer object.
  * @param {object} options - Options to configure the stream.
  * @param {number} options.waitInterval - Number of ms to wait if Kafka reports
  * that it has timed out or that we are out of messages (right now).
  * @param {array} options.topics - Array of topics, or a function that parses
- * metadata into an array of topics
+ * metadata into an array of topics.
+ *
+ * @example
+ *
+ * const stream = KafkaConsumer.createReadStream(globalConfig, null, {
+ *   topics: ['topic']
+ * });
+ *
+ * stream.on('data', (message) => {
+ *   console.log('Got message');
+ *   console.log(message.value.toString());
+ * });
  * @constructor
+ * @memberof RdKafka
  * @extends stream.Readable
  * @see Consumer~Message
  */
@@ -93,6 +106,11 @@ function KafkaConsumerStream(consumer, options) {
 
   Readable.call(this, options);
 
+  /**
+   * The KafkaConsumer that is being streamed from.
+   * Can be used to access any of the consumer methods directly.
+   * @type {RdKafka.KafkaConsumer}
+   */
   this.consumer = consumer;
   this.topics = topics;
   this.autoClose = options.autoClose === undefined ? true : !!options.autoClose;

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -24,21 +24,24 @@ const DEFAULT_IS_TIMEOUT_ONLY_FOR_FIRST_MESSAGE = false;
 util.inherits(KafkaConsumer, Client);
 
 /**
- * KafkaConsumer class for reading messages from Kafka
+ * KafkaConsumer class for reading messages from Kafka.
  *
  * This is the main entry point for reading data from Kafka. You
  * configure this like you do any other client, with a global
  * configuration and default topic configuration.
  *
- * Once you instantiate this object, connecting will open a socket.
  * Data will not be read until you tell the consumer what topics
  * you want to read from.
  *
- * @param {object} conf - Key value pairs to configure the consumer
- * @param {object} topicConf - Key value pairs to create a default
- * topic configuration
- * @extends Client
+ * Methods on a KafkaConsumer will throw a [LibrdKafkaError]{@link RdKafka.LibrdKafkaError}
+ * on failure.
+ *
+ * @param {object} conf - Key value pairs to configure the consumer.
+ * @param {object?} topicConf - Key value pairs to create a default topic configuration.
+ * @extends RdKafka.Client
+ * @memberof RdKafka
  * @constructor
+ * @see [Consumer example]{@link https://github.com/confluentinc/confluent-kafka-javascript/blob/master/examples/node-rdkafka/consumer-flow.md}
  */
 function KafkaConsumer(conf, topicConf) {
   if (!(this instanceof KafkaConsumer)) {
@@ -140,8 +143,9 @@ function KafkaConsumer(conf, topicConf) {
 }
 
 /**
- * Set the default consume timeout provided to c++land
- * @param {number} timeoutMs - number of milliseconds to wait for a message to be fetched
+ * Set the default consume timeout provided to C++land.
+ *
+ * @param {number} timeoutMs - number of milliseconds to wait for a message to be fetched.
  */
 KafkaConsumer.prototype.setDefaultConsumeTimeout = function(timeoutMs) {
   this._consumeTimeout = timeoutMs;
@@ -149,7 +153,8 @@ KafkaConsumer.prototype.setDefaultConsumeTimeout = function(timeoutMs) {
 
 /**
  * Set the default sleep delay for the next consume loop after the previous one has timed out.
- * @param {number} intervalMs - number of milliseconds to sleep after a message fetch has timed out
+ *
+ * @param {number} intervalMs - number of milliseconds to sleep after a message fetch has timed out.
  */
 KafkaConsumer.prototype.setDefaultConsumeLoopTimeoutDelay = function(intervalMs) {
   this._consumeLoopTimeoutDelay = intervalMs;
@@ -164,15 +169,15 @@ KafkaConsumer.prototype.setDefaultConsumeLoopTimeoutDelay = function(intervalMs)
  *  In consume(number, cb), we will wait for upto `timeoutMs` for each message to be fetched.
  *
  * @param {boolean} isTimeoutOnlyForFirstMessage
+ * @private
  */
 KafkaConsumer.prototype.setDefaultIsTimeoutOnlyForFirstMessage = function(isTimeoutOnlyForFirstMessage) {
   this._consumeIsTimeoutOnlyForFirstMessage = isTimeoutOnlyForFirstMessage;
 };
 
 /**
- * Get a stream representation of this KafkaConsumer
+ * Get a stream representation of this KafkaConsumer.
  *
- * @see TopicReadable
  * @example
  * var consumerStream = Kafka.KafkaConsumer.createReadStream({
  * 	'metadata.broker.list': 'localhost:9092',
@@ -181,13 +186,11 @@ KafkaConsumer.prototype.setDefaultIsTimeoutOnlyForFirstMessage = function(isTime
  * 	'enable.auto.commit': false
  * }, {}, { topics: [ 'test' ] });
  *
- * @param {object} conf - Key value pairs to configure the consumer
- * @param {object} topicConf - Key value pairs to create a default
- * topic configuration
- * @param {object} streamOptions - Stream options
+ * @param {object} conf - Key value pairs to configure the consumer.
+ * @param {object?} topicConf - Key value pairs to create a default topic configuration. May be null.
+ * @param {object} streamOptions - Stream options.
  * @param {array} streamOptions.topics - Array of topics to subscribe to.
- * @return {KafkaConsumerStream} - Readable stream that receives messages
- * when new ones become available.
+ * @return {RdKafka.KafkaConsumerStream} - Readable stream that receives messages when new ones become available.
  */
 KafkaConsumer.createReadStream = function(conf, topicConf, streamOptions) {
   var consumer = new KafkaConsumer(conf, topicConf);
@@ -195,17 +198,16 @@ KafkaConsumer.createReadStream = function(conf, topicConf, streamOptions) {
 };
 
 /**
- * Get a current list of the committed offsets per topic partition
+ * Get a current list of the committed offsets per topic partition.
  *
- * Returns an array of objects in the form of a topic partition list
+ * Calls back with array of objects in the form of a topic partition list.
  *
- * @param {TopicPartition[]} toppars - Topic partition list to query committed
- * offsets for. Defaults to the current assignment
+ * @param {TopicPartition[]?} toppars - Topic partition list to query committed
+ * offsets for. Defaults to the current assignment.
  * @param  {number} timeout - Number of ms to block before calling back
- * and erroring
- * @param  {Function} cb - Callback method to execute when finished or timed
- * out
- * @return {Client} - Returns itself
+ * and erroring.
+ * @param  {function} cb - Callback method to execute when finished or timed out.
+ * @return {RdKafka.KafkaConsumer} - Returns itself.
  */
 KafkaConsumer.prototype.committed = function(toppars, timeout, cb) {
   // We want to be backwards compatible here, and the previous version of
@@ -235,25 +237,22 @@ KafkaConsumer.prototype.committed = function(toppars, timeout, cb) {
  * Seek consumer for topic+partition to offset which is either an absolute or
  * logical offset.
  *
- * Does not return anything, as it is asynchronous. There are special cases
- * with the timeout parameter. The consumer must have previously been assigned
- * to topics and partitions that seek seeks to seek.
+ * The consumer must have previously been assigned to topics and partitions that
+ * are being seeked to in the call.
  *
  * @example
- * consumer.seek({ topic: 'topic', partition: 0, offset: 1000 }, 0, function(err) {
+ * consumer.seek({ topic: 'topic', partition: 0, offset: 1000 }, 2000, function(err) {
  *   if (err) {
  *
  *   }
  * });
  *
- * @param {TopicPartition} toppar - Topic partition to seek.
- * @param  {number} timeout - Number of ms to block before calling back
- * and erroring. If the parameter is null or 0, the call will not wait
- * for the seek to be performed. Essentially, it will happen in the background
- * with no notification
- * @param  {Function} cb - Callback method to execute when finished or timed
- * out. If the seek timed out, the internal state of the consumer is unknown.
- * @return {Client} - Returns itself
+ * @param {TopicPartition} toppar - Topic partition to seek, including offset.
+ * @param  {number} timeout - Number of ms to try seeking before erroring out.
+ * @param  {function} cb - Callback method to execute when finished or timed
+ *                         out. If the seek timed out, the internal state of the
+ *                         consumer is unknown.
+ * @return {RdKafka.KafkaConsumer} - Returns itself.
  */
 KafkaConsumer.prototype.seek = function(toppar, timeout, cb) {
   this._client.seek(TopicPartition.create(toppar), timeout, function(err) {
@@ -269,25 +268,24 @@ KafkaConsumer.prototype.seek = function(toppar, timeout, cb) {
 
 /**
  * Assign the consumer specific partitions and topics. Used for
- * eager (non-cooperative) rebalancing.
+ * eager (non-cooperative) rebalancing from within the rebalance callback.
  *
  * @param {array} assignments - Assignments array. Should contain
  * objects with topic and partition set.
- * @return {Client} - Returns itself
- * @sa KafkaConsumer::incrementalAssign
+ * @return {RdKafka.KafkaConsumer} - Returns itself.
+ * @see RdKafka.KafkaConsumer#incrementalAssign
  */
-
 KafkaConsumer.prototype.assign = function(assignments) {
   this._client.assign(TopicPartition.map(assignments));
   return this;
 };
 
 /**
- * Unassign the consumer from its assigned partitions and topics.Used for
- * eager (non-cooperative) rebalancing.
+ * Unassign the consumer from its assigned partitions and topics. Used for
+ * eager (non-cooperative) rebalancing from within the rebalance callback.
  *
- * @return {Client} - Returns itself
- * @sa KafkaConsumer::incrementalUnassign
+ * @return {RdKafka.KafkaConsumer} - Returns itself.
+ * @see RdKafka.KafkaConsumer#incrementalUnassign
  */
 
 KafkaConsumer.prototype.unassign = function() {
@@ -297,12 +295,12 @@ KafkaConsumer.prototype.unassign = function() {
 
 /**
  * Assign the consumer specific partitions and topics. Used for
- * cooperative rebalancing.
+ * cooperative rebalancing from within the rebalance callback.
  *
  * @param {array} assignments - Assignments array. Should contain
  * objects with topic and partition set. Assignments are additive.
- * @return {Client} - Returns itself
- * @sa KafkaConsumer::assign
+ * @return {RdKafka.KafkaConsumer} - Returns itself.
+ * @see RdKafka.KafkaConsumer#assign
  */
 KafkaConsumer.prototype.incrementalAssign = function(assignments) {
   this._client.incrementalAssign(TopicPartition.map(assignments));
@@ -311,12 +309,12 @@ KafkaConsumer.prototype.incrementalAssign = function(assignments) {
 
 /**
  * Unassign the consumer specific partitions and topics. Used for
- * cooperative rebalancing.
+ * cooperative rebalancing from within the rebalance callback.
  *
  * @param {array} assignments - Assignments array. Should contain
  * objects with topic and partition set. Assignments are subtractive.
- * @return {Client} - Returns itself
- * @sa KafkaConsumer::unassign
+ * @return {RdKafka.KafkaConsumer} - Returns itself.
+ * @see RdKafka.KafkaConsumer#unassign
  */
 KafkaConsumer.prototype.incrementalUnassign = function(assignments) {
   this._client.incrementalUnassign(TopicPartition.map(assignments));
@@ -324,11 +322,10 @@ KafkaConsumer.prototype.incrementalUnassign = function(assignments) {
 };
 
 /**
- * Get the assignments for the consumer
+ * Get the assignments for the consumer.
  *
- * @return {array} assignments - Array of topic partitions
+ * @return {array} assignments - Array of topic partitions.
  */
-
 KafkaConsumer.prototype.assignments = function() {
   return this._errorWrap(this._client.assignments(), true);
 };
@@ -339,7 +336,7 @@ KafkaConsumer.prototype.assignments = function() {
  * @note This method should only be called from within the rebalance callback
  * when partitions are revoked.
  *
- * @return {boolean} true if assignment was lost
+ * @return {boolean} true if assignment was lost.
  */
 
 KafkaConsumer.prototype.assignmentLost = function() {
@@ -349,7 +346,7 @@ KafkaConsumer.prototype.assignmentLost = function() {
 /**
  * Get the type of rebalance protocol used in the consumer group.
  *
- * @returns "NONE" (if not in a group yet), "COOPERATIVE" or "EAGER".
+ * @returns {string} "NONE" (if not in a group yet), "COOPERATIVE" or "EAGER".
  */
 KafkaConsumer.prototype.rebalanceProtocol = function() {
   return this._client.rebalanceProtocol();
@@ -366,42 +363,49 @@ KafkaConsumer.prototype.rebalanceProtocol = function() {
  *
  * This is also a good way to do it for streams.
  *
- * @param  {array} topics - An array of topics to listen to
- * @throws - Throws when an error code came back from native land
+ * This does not actually cause any reassignment of topic partitions until
+ * the consume loop is running or the consume method is called.
+ *
+ * @param  {array} topics - An array of topics to listen to.
+ * @fires RdKafka.KafkaConsumer#subscribed
  * @return {KafkaConsumer} - Returns itself.
  */
 KafkaConsumer.prototype.subscribe = function(topics) {
   // Will throw if it is a bad error.
   this._errorWrap(this._client.subscribe(topics));
+  /**
+   * Subscribe event. Called efter changing subscription.
+   *
+   * @event RdKafka.KafkaConsumer#subscribed
+   * @type {Array<string>}
+   */
   this.emit('subscribed', topics);
   return this;
 };
 
 /**
- * Get the current subscription of the KafkaConsumer
+ * Get the current subscription of the KafkaConsumer.
  *
  * Get a list of subscribed topics. Should generally match what you
- * passed on via subscribe
+ * passed on via subscribe.
  *
- * @see KafkaConsumer::subscribe
- * @throws - Throws when an error code came back from native land
- * @return {array} - Array of strings to show the current assignment
+ * @see RdKafka.KafkaConsumer#subscribe
+ * @return {array} - Array of topic string to show the current subscription.
  */
 KafkaConsumer.prototype.subscription = function() {
   return this._errorWrap(this._client.subscription(), true);
 };
 
 /**
- * Get the current offset position of the KafkaConsumer
+ * Get the current offset position of the KafkaConsumer.
  *
- * Returns a list of RdKafka::TopicPartitions on success, or throws
- * an error on failure
+ * Returns a list of TopicPartitions on success, or throws
+ * an error on failure.
  *
  * @param {TopicPartition[]} toppars - List of topic partitions to query
- * position for. Defaults to the current assignment
- * @throws - Throws when an error code came back from native land
+ * position for. Defaults to the current assignment.
  * @return {array} - TopicPartition array. Each item is an object with
- * an offset, topic, and partition
+ * an offset, topic, and partition.
  */
 KafkaConsumer.prototype.position = function(toppars) {
   if (!toppars) {
@@ -411,15 +415,14 @@ KafkaConsumer.prototype.position = function(toppars) {
 };
 
 /**
- * Unsubscribe from all currently subscribed topics
+ * Unsubscribe from all currently subscribed topics.
  *
  * Before you subscribe to new topics you need to unsubscribe
  * from the old ones, if there is an active subscription.
  * Otherwise, you will get an error because there is an
  * existing subscription.
  *
- * @throws - Throws when an error code comes back from native land
- * @return {KafkaConsumer} - Returns itself.
+ * @return {RdKafka.KafkaConsumer} - Returns itself.
  */
 KafkaConsumer.prototype.unsubscribe = function() {
   this._errorWrap(this._client.unsubscribe());
@@ -430,28 +433,46 @@ KafkaConsumer.prototype.unsubscribe = function() {
 };
 
 /**
- * Read a number of messages from Kafka.
+ * Consume messages from the subscribed topics.
  *
- * This method is similar to the main one, except that it reads a number
- * of messages before calling back. This may get better performance than
- * reading a single message each time in stream implementations.
+ * This method can be used in two ways.
  *
- * This will keep going until it gets ERR__PARTITION_EOF or ERR__TIMED_OUT
- * so the array may not be the same size you ask for. The size is advisory,
- * but we will not exceed it.
+ * 1. To read messages as fast as possible.
+ *    A background thread is created to fetch the messages as quickly as it can,
+ *    sleeping only in between EOF and broker timeouts.
+ *    If called in this way, the method returns immediately. Messages will be
+ *    sent via an optional callback that can be provided to the method, and via
+ *    the [data]{@link RdKafka.KafkaConsumer#data} event.
  *
- * @param {number} size - Number of messages to read
- * @param {KafkaConsumer~readCallback} cb - Callback to return when work is done.
- *//**
- * Read messages from Kafka as fast as possible
+ * 2. To read a certain number of messages.
+ *    If the first argument provided is a number, this method reads multiple
+ *    messages, the count of which doesn't exceed the number. No additional thread
+ *    is created.
  *
- * This method keeps a background thread running to fetch the messages
- * as quickly as it can, sleeping only in between EOF and broker timeouts.
+ * Configuring timeouts for consume:
  *
- * Use this to get the maximum read performance if you don't care about the
- * stream backpressure.
- * @param {KafkaConsumer~readCallback} cb - Callback to return when a message
- * is fetched.
+ * 1. [setDefaultConsumeTimeout]{@link RdKafka.KafkaConsumer#setDefaultConsumeTimeout} -
+ *    This is the time we wait for a message to be fetched from the underlying library.
+ *    If this is exceeded, we either backoff for a while (Way 1), or return with however
+ *    many messages we've already fetched by that point (Way 2).
+ *
+ * 2. [setDefaultConsumeLoopTimeoutDelay]{@link RdKafka.KafkaConsumer#setDefaultConsumeLoopTimeoutDelay} -
+ *    This is the time we wait before attempting another fetch after a message fetch has timed out.
+ *    This is only used in Way 1.
+ *
+ * @example
+ * // Way 1:
+ * consumer.consume(); // No callback is okay.
+ * consumer.consume(processMessage); // Messages will be send to the callback.
+ *
+ * // Way 2:
+ * consumer.consume(10); // First parameter must be number of messages.
+ * consumer.consume(10, processMessage); // Callback can be given as the second parameter.
+ *
+ * @param {number|function|null} sizeOrCb - Either the number of messages to
+ *                                          read (if using in second way, or the
+ *                                          callback) if using the first way.
+ * @param {RdKafka.KafkaConsumer~readCallback?} cb - Callback to return when work is done, if using second way.
  */
 KafkaConsumer.prototype.consume = function(number, cb) {
   var timeoutMs = this._consumeTimeout !== undefined ? this._consumeTimeout : DEFAULT_CONSUME_TIME_OUT;
@@ -510,8 +531,8 @@ KafkaConsumer.prototype._consumeLoop = function(timeoutMs, cb) {
       /**
        * Data event. called whenever a message is received.
        *
-       * @event KafkaConsumer#data
-       * @type {KafkaConsumer~Message}
+       * @event RdKafka.KafkaConsumer#data
+       * @type {RdKafka.KafkaConsumer~Message}
        */
       self.emit('data', message);
       cb(err, message);
@@ -577,16 +598,19 @@ KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
  */
 
 /**
- * Commit a topic partition or all topic partitions that have been read
+ * Commit specific topic partitions, or all the topic partitions that have been read.
  *
- * If you provide a topic partition, it will commit that. Otherwise,
- * it will commit all read offsets for all topic partitions.
+ * This is asynchronous, and when this method returns, it's not guaranteed that the
+ * offsets have been committed. If you need that, use
+ * [commitSync]{@link RdKafka.KafkaConsumer#commitSync} or
+ * [commitCb]{@link RdKafka.KafkaConsumer#commitCb}.
+ *
+ * If you provide a topic partition, or an array of topic parrtitins, it will commit those.
+ * Otherwise, it will commit all read offsets for all topic partitions.
  *
  * @param {object|array|null} - Topic partition object to commit, list of topic
  * partitions, or null if you want to commit all read offsets.
- * @throws When commit returns a non 0 error code
- *
- * @return {KafkaConsumer} - returns itself.
+ * @return {RdKafka.KafkaConsumer} - returns itself.
  */
 KafkaConsumer.prototype.commit = function(topicPartition) {
   this._errorWrap(this._client.commit(topicPartition), true);
@@ -594,15 +618,14 @@ KafkaConsumer.prototype.commit = function(topicPartition) {
 };
 
 /**
- * Commit a message
+ * Commit a message.
  *
- * This is basically a convenience method to map commit properly. We need to
- * add one to the offset in this case
+ * This is a convenience method to map commit properly. The offset of the message + 1 is committed
+ * for the topic partition where the message comes from.
  *
- * @param {object} - Message object to commit
- * @throws When commit returns a non 0 error code
+ * @param {object} - Message object to commit.
  *
- * @return {KafkaConsumer} - returns itself.
+ * @return {RdKafka.KafkaConsumer} - returns itself.
  */
 KafkaConsumer.prototype.commitMessage = function(msg) {
   var topicPartition = {
@@ -617,13 +640,11 @@ KafkaConsumer.prototype.commitMessage = function(msg) {
 };
 
 /**
- * Commit a topic partition (or all topic partitions) synchronously
+ * Commit a topic partition (or all topic partitions) synchronously.
  *
  * @param {object|array|null} - Topic partition object to commit, list of topic
  * partitions, or null if you want to commit all read offsets.
- * @throws {LibrdKafkaError} - if the commit fails
- *
- * @return {KafkaConsumer} - returns itself.
+ * @return {RdKafka.KafkaConsumer} - returns itself.
  */
 KafkaConsumer.prototype.commitSync = function(topicPartition) {
   this._errorWrap(this._client.commitSync(topicPartition), true);
@@ -631,14 +652,11 @@ KafkaConsumer.prototype.commitSync = function(topicPartition) {
 };
 
 /**
- * Commit a message synchronously
+ * Commit a message synchronously.
  *
- * @see KafkaConsumer#commitMessageSync
+ * @see RdKafka.KafkaConsumer#commitMessageSync
  * @param  {object} msg - A message object to commit.
- *
- * @throws {LibrdKafkaError} - if the commit fails
- *
- * @return {KafkaConsumer} - returns itself.
+ * @return {RdKafka.KafkaConsumer} - returns itself.
  */
 KafkaConsumer.prototype.commitMessageSync = function(msg) {
   var topicPartition = {
@@ -656,9 +674,9 @@ KafkaConsumer.prototype.commitMessageSync = function(msg) {
  * Commits a list of offsets per topic partition, using provided callback.
  *
  * @param {TopicPartition[]} toppars - Topic partition list to commit
- * offsets for. Defaults to the current assignment
- * @param  {Function} cb - Callback method to execute when finished
- * @return {Client} - Returns itself
+ * offsets for. Defaults to the current assignment.
+ * @param  {function} cb - Callback method to execute when finished.
+ * @return {RdKafka.KafkaConsumer} - returns itself.
  */
 KafkaConsumer.prototype.commitCb = function(toppars, cb) {
   this._client.commitCb(toppars, function(err) {
@@ -683,10 +701,9 @@ KafkaConsumer.prototype.commitCb = function(toppars, cb) {
  * throw an error.
  *
  * @param {string} topic - Topic to recieve offsets from.
- * @param {number} partition - Partition of the provided topic to recieve offsets from
- * @return {Client~watermarkOffsets} - Returns an object with a high and low property, specifying
- * the high and low offsets for the topic partition
- * @throws {LibrdKafkaError} - Throws when there is no offset stored
+ * @param {number} partition - Partition of the provided topic to recieve offsets from.
+ * @return {RdKafka.Client~watermarkOffsets} - Returns an object with a high and low property, specifying
+ * the high and low offsets for the topic partition.
  */
 KafkaConsumer.prototype.getWatermarkOffsets = function(topic, partition) {
   if (!this.isConnected()) {
@@ -702,12 +719,11 @@ KafkaConsumer.prototype.getWatermarkOffsets = function(topic, partition) {
  * The offset will be committed (written) to the offset store according to the auto commit interval,
  * if auto commit is on, or next manual offset if not.
  *
- * enable.auto.offset.store must be set to false to use this API,
+ * enable.auto.offset.store must be set to false to use this API.
  *
- * @see https://github.com/confluentinc/librdkafka/blob/261371dc0edef4cea9e58a076c8e8aa7dc50d452/src-cpp/rdkafkacpp.h#L1702
+ * @see {@link https://github.com/confluentinc/librdkafka/blob/261371dc0edef4cea9e58a076c8e8aa7dc50d452/src-cpp/rdkafkacpp.h#L1702}
  *
  * @param {Array.<TopicPartition>} topicPartitions - Topic partitions with offsets to store offsets for.
- * @throws {LibrdKafkaError} - Throws when there is no offset stored
  */
 KafkaConsumer.prototype.offsetsStore = function(topicPartitions) {
   if (!this.isConnected()) {
@@ -726,7 +742,7 @@ KafkaConsumer.prototype.offsetsStore = function(topicPartitions) {
  * @param {number} partition - Partition of the provided topic to store offset for.
  * @param {number} offset - Offset to store.
  * @param {number} leaderEpoch - Leader epoch of the provided offset.
- * @throws {LibrdKafkaError} - Throws when there is no offset stored
+ * @private
  */
 KafkaConsumer.prototype._offsetsStoreSingle = function(topic, partition, offset, leaderEpoch) {
   if (!this.isConnected()) {
@@ -741,7 +757,6 @@ KafkaConsumer.prototype._offsetsStoreSingle = function(topic, partition, offset,
  * Resume consumption for the provided list of partitions.
  *
  * @param {Array.<TopicPartition>} topicPartitions - List of topic partitions to resume consumption on.
- * @throws {LibrdKafkaError} - Throws when there is no offset stored
  */
 KafkaConsumer.prototype.resume = function(topicPartitions) {
   if (!this.isConnected()) {
@@ -752,10 +767,9 @@ KafkaConsumer.prototype.resume = function(topicPartitions) {
 };
 
 /**
- * Pause producing or consumption for the provided list of partitions.
+ * Pause consumption for the provided list of partitions.
  *
  * @param {Array.<TopicPartition>} topicPartitions - List of topics to pause consumption on.
- * @throws {LibrdKafkaError} - Throws when there is no offset stored
  */
 KafkaConsumer.prototype.pause = function(topicPartitions) {
   if (!this.isConnected()) {
@@ -764,3 +778,21 @@ KafkaConsumer.prototype.pause = function(topicPartitions) {
 
   return this._errorWrap(this._client.pause(topicPartitions), true);
 };
+
+/**
+ * @typedef {object} RdKafka.KafkaConsumer~MessageHeader
+ * The key of this object denotes the header key, and the value of the key is the header value.
+ */
+
+/**
+ * @typedef {object} RdKafka.KafkaConsumer~Message
+ * @property {string} topic - The topic the message was read from.
+ * @property {number} partition - The partition the message was read from.
+ * @property {number} offset - The offset of the message.
+ * @property {Buffer?} key - The key of the message.
+ * @property {Buffer?} value - The value of the message.
+ * @property {number} size - The size of the message.
+ * @property {number} timestamp - The timestamp of the message (in milliseconds since the epoch in UTC).
+ * @property {number?} leaderEpoch - The leader epoch of the message if available.
+ * @property {RdKafka.KafkaConsumer~MessageHeader[]?} headers - The headers of the message.
+ */

--- a/lib/kafkajs/_admin.js
+++ b/lib/kafkajs/_admin.js
@@ -11,11 +11,6 @@ const { kafkaJSToRdKafkaConfig,
 } = require('./_common');
 const error = require('./_error');
 
-/**
- * NOTE: The Admin client is currently in an experimental state with many
- *       features missing or incomplete, and the API is subject to change.
- */
-
 const AdminState = Object.freeze({
   INIT: 0,
   CONNECTING: 1,
@@ -24,6 +19,30 @@ const AdminState = Object.freeze({
   DISCONNECTED: 6,
 });
 
+/**
+ * Admin client for administering Kafka clusters (promise-based, async API).
+ *
+ * This client is the way you can interface with the Kafka Admin APIs.
+ * This class should not be instantiated directly, and rather, an instance of
+ * [Kafka]{@link KafkaJS.Kafka} should be used to create it, or an existing
+ * Producer or Consumer's `dependentAdmin` method may be used.
+ *
+ * @example
+ * const { Kafka } = require('@confluentinc/kafka-javascript');
+ * // From a Kafka object.
+ * const kafka = new Kafka({ 'bootstrap.servers': 'localhost:9092' });
+ * const admin = kafka.admin();
+ * await admin.connect();
+ * await admin.createTopics({ });
+ *
+ * // From a producer/consumer
+ * const admin = preExistingProducer.dependentAdmin();
+ * await admin.connect();
+ * await admin.createTopics({ });
+ *
+ * @memberof KafkaJS
+ * @see [Admin client examples]{@link https://github.com/confluentinc/confluent-kafka-javascript/blob/master/examples/kafkajs/admin}
+ */
 class Admin {
   /**
    * The config supplied by the user.
@@ -72,9 +91,7 @@ class Admin {
    */
   #existingClient = null;
 
-  /**
-   * Convenience function to create the metadata object needed for logging.
-   */
+  // Convenience function to create the metadata object needed for logging.
   #createAdminBindingMessageMetadata() {
     return createBindingMessageMetadata(this.#clientName);
   }
@@ -165,6 +182,7 @@ class Admin {
   /**
    * Callback for the event.error event, either fails the initial connect(), or logs the error.
    * @param {Error} err
+   * @private
    */
   #errorCb(err) {
     if (this.#state === AdminState.CONNECTING) {
@@ -249,6 +267,7 @@ class Admin {
    * Converts a topic configuration object from kafkaJS to a format suitable for node-rdkafka.
    * @param {import("../../types/kafkajs").ITopicConfig} topic
    * @returns {import("../../index").NewTopic}
+   * @private
    */
   #topicConfigToRdKafka(topic) {
     let topicConfig = { topic: topic.topic };
@@ -271,7 +290,10 @@ class Admin {
 
   /**
    * Create topics with the given configuration.
-   * @param {{ validateOnly?: boolean, waitForLeaders?: boolean, timeout?: number, topics: import("../../types/kafkajs").ITopicConfig[] }} options
+   * @param {object} options
+   * @param {number?} options.timeout - The request timeout in milliseconds (default: 5000).
+   * @param {Array<{topic: string, numPartitions: number | null, replicationFactor: number | null, configEntries: Array<{name: string, value: string}> | null}>} options.topics
+   * The topics to create and optionally, the configuration for each topic.
    * @returns {Promise<boolean>} Resolves true when the topics are created, false if topic exists already, rejects on error.
    *                             In case even one topic already exists, this will return false.
    */
@@ -313,7 +335,9 @@ class Admin {
 
   /**
    * Deletes given topics.
-   * @param {{topics: string[], timeout?: number}} options
+   * @param {object} options
+   * @param {Array<string>} options.topics - The topics to delete.
+   * @param {number?} options.timeout - The request timeout in milliseconds (default: 5000).
    * @returns {Promise<void>} Resolves when the topics are deleted, rejects on error.
    */
   async deleteTopics(options) {
@@ -339,10 +363,10 @@ class Admin {
    *
    * @param {object?} options
    * @param {number?} options.timeout - The request timeout in milliseconds.
-   *                                    May be unset (default: 5000)
-   * @param {import("../../types/kafkajs").ConsumerGroupStates[]?} options.matchConsumerGroupStates -
+   *                                    May be unset (default: 5000).
+   * @param {Array<KafkaJS.ConsumerGroupStates>?} options.matchConsumerGroupStates -
    *        A list of consumer group states to match. May be unset, fetches all states (default: unset).
-   * @returns {Promise<{ groups: import("../../types/kafkajs").GroupOverview[], errors: import("../../types/kafkajs").LibrdKafkaError[] }>}
+   * @returns {Promise<{ groups: Array<{groupId: string, protocolType: string, isSimpleConsumerGroup: boolean, state: KafkaJS.ConsumerGroupStates}>, errors: Array<RdKafka.LibrdKafkaError> }>}
    *          Resolves with the list of consumer groups, rejects on error.
    */
   async listGroups(options = {}) {
@@ -364,12 +388,12 @@ class Admin {
   /**
    * Describe consumer groups.
    *
-   * @param {string[]} groups - The names of the groups to describe.
+   * @param {Array<string>} groups - The names of the groups to describe.
    * @param {object?} options
    * @param {number?} options.timeout - The request timeout in milliseconds.
    *                                    May be unset (default: 5000)
    * @param {boolean?} options.includeAuthorizedOperations - If true, include operations allowed on the group by the calling client (default: false).
-   * @returns {Promise<import("../../types/kafkajs").GroupDescriptions>}
+   * @returns {Promise<{groups: Array<object>}>} The descriptions of the requested groups.
    */
   async describeGroups(groups, options = {}) {
     if (this.#state !== AdminState.CONNECTED) {
@@ -389,11 +413,12 @@ class Admin {
 
   /**
    * Delete consumer groups.
-   * @param {string[]} groups - The names of the groups to delete.
-   * @param {any?} options
+   * @param {Array<string>} groups - The names of the groups to delete.
+   * @param {object?} options
    * @param {number?} options.timeout - The request timeout in milliseconds.
    *                                    May be unset (default: 5000)
-   * @returns {Promise<import("../../types/kafkajs").DeleteGroupsResult[]>}
+   * @returns {Promise<Array<{groupId: string, errorCode: number | null, error: RdKafka.LibrdKafkaError | null}>>}
+   *          Resolves with the list of deletion reports (including per-group errors).
    */
   async deleteGroups(groups, options = {}) {
     if (this.#state !== AdminState.CONNECTED) {
@@ -414,10 +439,10 @@ class Admin {
   /**
    * List topics.
    *
-   * @param {any?} options
+   * @param {object?} options
    * @param {number?} options.timeout - The request timeout in milliseconds.
-   *                                    May be unset (default: 5000)
-   * @returns {Promise<string[]>}
+   *                                    May be unset (default: 5000).
+   * @returns {Promise<Array<string>>} The list of all topics.
    */
   async listTopics(options = {}) {
     if (this.#state !== AdminState.CONNECTED) {
@@ -438,15 +463,18 @@ class Admin {
   /**
    * Fetch the offsets for topic partition(s) for consumer group(s).
    *
+   * @param {object?} options
    * @param {string} options.groupId - The group ID to fetch offsets for.
-   * @param {import("../../types/kafkajs").TopicInput} options.topics - The topics to fetch offsets for.
-   * @param {boolean} options.resolveOffsets - not yet implemented
+   * @param {Array<string> | Array<{topic: string, partitions: Array<number>}>} options.topics
+   *        The topics to fetch offsets for. Can be specified as a list of topics (in case offsets for all topics are fetched),
+   *        or as a list of objects, each containing a topic and a list of partitions.
    * @param {number?} options.timeout - The request timeout in milliseconds.
-   *                                    May be unset (default: 5000)
+   *                                    May be unset (default: 5000).
    * @param {boolean?} options.requireStableOffsets - Whether broker should return stable offsets
-   *                                                  (transaction-committed). (default: false)
+   *                                                  (transaction-committed). (default: false).
    *
-   * @returns {Promise<Array<topic: string, partitions: import('../../types/kafkajs').FetchOffsetsPartition>>}
+   * @returns {Promise<Array<{topic: string, partitions: Array<object>}>>}
+   *          The list of requested offsets.
    */
   async fetchOffsets(options = {}) {
     if (this.#state !== AdminState.CONNECTED) {
@@ -554,16 +582,20 @@ class Admin {
 
   /**
    * Deletes records (messages) in topic partitions older than the offsets provided.
-   * Provide -1 as offset to delete all records.
    *
+   * Provide -1 as offset to delete all records in the partition.
+   *
+   * @param {object} options
    * @param {string} options.topic - The topic to delete offsets for.
-   * @param {import("../../types/kafkajs").SeekEntry[]} options.partitons - The partitions to delete offsets for.
+   * @param {Array<{partition: number, offset: string}>} options.partitions
+   *        The partitions and associated offsets to delete up until.
    * @param {number?} options.operationTimeout - The operation timeout in milliseconds.
-   *                                             May be unset (default: 60000)
+   *                                             May be unset (default: 60000).
    * @param {number?} options.timeout - The request timeout in milliseconds.
-   *                                    May be unset (default: 5000)
+   *                                    May be unset (default: 5000).
    *
-   * @returns {Promise<import('../../types/kafkajs').DeleteRecordsResult[]>>}
+   * @returns {Promise<Array<{topic: string, partition: number, lowWatermark: number, error: RdKafka.LibrdKafkaError | null}>>}
+   *          A list of results for each partition.
    */
   async deleteTopicRecords(options = {}) {
     if (this.#state !== AdminState.CONNECTED) {
@@ -610,14 +642,15 @@ class Admin {
   /**
    * Describe topics.
    *
-   * @param {string[]} options.topics - The topics to describe.
+   * @param {object?} options
+   * @param {Array<string>} options.topics - The topics to describe.
    *                                    If unset, all topics will be described.
    * @param {number?} options.timeout - The request timeout in milliseconds.
-   *                                    May be unset (default: 5000)
+   *                                    May be unset (default: 5000).
    * @param {boolean?} options.includeAuthorizedOperations - If true, include operations allowed on the topic
    *                                                         by the calling client (default: false).
    *
-   * @returns {Promise<{ topics: Array<import('../../types/kafkajs').ITopicMetadata> }>}
+   * @returns {Promise<{ topics: Array<object> }>}
    */
   async fetchTopicMetadata(options = {}) {
     if (this.#state !== AdminState.CONNECTED) {
@@ -670,6 +703,20 @@ class Admin {
 
 module.exports = {
   Admin,
+  /**
+   * A list of consumer group states.
+   * @enum {number}
+   * @readonly
+   * @memberof KafkaJS
+   * @see RdKafka.ConsumerGroupStates
+   */
   ConsumerGroupStates: RdKafka.AdminClient.ConsumerGroupStates,
+  /**
+   * A list of ACL operation types.
+   * @enum {number}
+   * @readonly
+   * @memberof KafkaJS
+   * @see RdKafka.AclOperationTypes
+   */
   AclOperationTypes: RdKafka.AdminClient.AclOperationTypes
 };

--- a/lib/kafkajs/_admin.js
+++ b/lib/kafkajs/_admin.js
@@ -723,7 +723,7 @@ class Admin {
    * @param {KafkaJS.IsolationLevel?} options.isolationLevel - The isolation level for reading the offsets.
    *                                                           (default: READ_UNCOMMITTED)
    *
-   * @returns {Promise<Array<{partition: number, offset: string, high: string; low: string}>>}
+   * @returns {Promise<Array<{partition: number, offset: string, high: string, low: string}>>}
    */
   async fetchTopicOffsets(topic, options = {}) {
     if (this.#state !== AdminState.CONNECTED) {

--- a/lib/kafkajs/_common.js
+++ b/lib/kafkajs/_common.js
@@ -57,13 +57,19 @@ const kafkaJSProperties = {
   admin: [],
 };
 
-const logLevel = Object.freeze({
+/**
+ * A list of supported log levels.
+ * @enum {number}
+ * @readonly
+ * @memberof KafkaJS
+ */
+const logLevel = {
   NOTHING: 0,
   ERROR: 1,
   WARN: 2,
   INFO: 3,
   DEBUG: 4,
-});
+};
 
 const severityToLogLevel = Object.freeze({
   0: logLevel.NOTHING,
@@ -79,6 +85,7 @@ const severityToLogLevel = Object.freeze({
 /**
  * Default logger implementation.
  * @type import("../../types/kafkajs").Logger
+ * @private
  */
 class DefaultLogger {
   constructor() {
@@ -119,6 +126,7 @@ class DefaultLogger {
  * Returned object is intended to be used immediately and not stored.
  *
  * @param {string|undefined} clientName
+ * @private
  */
 function createBindingMessageMetadata(clientName) {
   return {
@@ -131,6 +139,7 @@ function createBindingMessageMetadata(clientName) {
 /**
  * Trampoline for user defined logger, if any.
  * @param {{severity: number, fac: string, message: string}} msg
+ * @private
  *
  */
 function loggerTrampoline(msg, logger) {
@@ -271,6 +280,7 @@ const CompatibilityErrorMessages = Object.freeze({
  * @throws {error.KafkaJSError} if the configuration is invalid.
  *                              The error code will be ERR__INVALID_ARG in case of invalid arguments or features that are not supported.
  *                              The error code will be ERR__NOT_IMPLEMENTED in case of features that are not yet implemented.
+ * @private
  */
 function kafkaJSToRdKafkaConfig(config) {
   /* Since the kafkaJS block is specified, we operate in
@@ -462,6 +472,7 @@ function kafkaJSToRdKafkaConfig(config) {
  * @param {'producer'|'consumer'|'admin'} clientType
  * @param {any} config
  * @returns {string|null} the first unsupported key, or null if all keys are supported.
+ * @private
  */
 function checkAllowedKeys(clientType, config) {
   const allowedKeysCommon = kafkaJSProperties.common;
@@ -487,6 +498,7 @@ function checkAllowedKeys(clientType, config) {
  * @param {'producer'|'consumer'|'admin'|'common'} propertyType
  * @param {any} config
  * @returns {string|null} the first KafkaJS specific key, or null if none is present.
+ * @private
  */
 function checkIfKafkaJsKeysPresent(propertyType, config) {
   if (!Object.hasOwn(kafkaJSProperties, propertyType)) {
@@ -511,6 +523,7 @@ function checkIfKafkaJsKeysPresent(propertyType, config) {
  * Converts a topicPartitionOffset from KafkaJS to a format that can be used by node-rdkafka.
  * @param {import("../../types/kafkajs").TopicPartitionOffset} tpo
  * @returns {{topic: string, partition: number, offset: number}}
+ * @private
  */
 function topicPartitionOffsetToRdKafka(tpo) {
   // TODO: do we need some checks for negative offsets and stuff? Or 'named' offsets?
@@ -528,6 +541,7 @@ function topicPartitionOffsetToRdKafka(tpo) {
  *
  * @param {import("../../types/kafkajs").TopicPartitionOffsetAndMetadata} tpo
  * @returns {import("../../types/rdkafka").TopicPartitionOffsetAndMetadata}
+ * @private
  */
 function topicPartitionOffsetMetadataToRdKafka(tpo) {
   return {
@@ -545,6 +559,7 @@ function topicPartitionOffsetMetadataToRdKafka(tpo) {
  *
  * @param {import("../../types/rdkafka").TopicPartitionOffsetAndMetadata} tpo
  * @returns {import("../../types/kafkajs").TopicPartitionOffsetAndMetadata}
+ * @private
  */
 function topicPartitionOffsetMetadataToKafkaJS(tpo) {
   return {
@@ -560,6 +575,7 @@ function topicPartitionOffsetMetadataToKafkaJS(tpo) {
  * Convert a librdkafka error from node-rdkafka into a KafkaJSError.
  * @param {import("../error")} librdKafkaError to convert from.
  * @returns {error.KafkaJSError} the converted error.
+ * @private
  */
 function createKafkaJsErrorFromLibRdKafkaError(librdKafkaError) {
   const properties = {
@@ -603,6 +619,7 @@ function createKafkaJsErrorFromLibRdKafkaError(librdKafkaError) {
  * Converts KafkaJS headers to a format that can be used by node-rdkafka.
  * @param {import("../../types/kafkajs").IHeaders|null} kafkaJSHeaders
  * @returns {import("../../").MessageHeader[]|null} the converted headers.
+ * @private
  */
 function convertToRdKafkaHeaders(kafkaJSHeaders) {
   if (!kafkaJSHeaders) return null;
@@ -631,6 +648,7 @@ function notImplemented(msg = 'Not implemented') {
 
 /**
  * A promise that can be resolved externally.
+ * @private
  */
 class DeferredPromise extends Promise{
   #resolved = false;
@@ -662,6 +680,7 @@ class DeferredPromise extends Promise{
 
 /**
  * Utility class for time related functions
+ * @private
  */
 class Timer {
   /**
@@ -700,6 +719,7 @@ class Timer {
  * Readers-writer lock with reentrant calls.
  * Upgrading from a read to a write lock is supported.
  * Acquiring a read lock while holding a write lock is a no-op.
+ * @private
  */
 class Lock {
   // Total number of readers, not increases when already holding a write lock
@@ -837,6 +857,7 @@ class Lock {
  * Creates a key for maps from a topicPartition object.
  * @param {{topic: string, partition: number}} topicPartition Any object which can be treated as a topic partition.
  * @returns {string} The created key.
+ * @private
  */
 function partitionKey(topicPartition) {
   return topicPartition.topic + '|'+ (topicPartition.partition);
@@ -851,7 +872,7 @@ module.exports = {
   convertToRdKafkaHeaders,
   createBindingMessageMetadata,
   notImplemented,
-  logLevel,
+  logLevel: Object.freeze(logLevel),
   loggerTrampoline,
   DefaultLogger,
   createReplacementErrorMessage,

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -34,12 +34,38 @@ const ConsumerState = Object.freeze({
   DISCONNECTED: 4,
 });
 
-const PartitionAssigners = Object.freeze({
+/**
+ * A list of supported partition assignor types.
+ * @enum {string}
+ * @readonly
+ * @memberof KafkaJS
+ */
+const PartitionAssigners = {
   roundRobin: 'roundrobin',
   range: 'range',
   cooperativeSticky: 'cooperative-sticky',
-});
+};
 
+/**
+ * Consumer for reading messages from Kafka (promise-based, async API).
+ *
+ * The consumer allows reading messages from the Kafka cluster, and provides
+ * methods to configure and control various aspects of that. This class should
+ * not be instantiated directly, and rather, an instance of
+ * [Kafka]{@link KafkaJS.Kafka} should be used.
+ *
+ * @example
+ * const { Kafka } = require('@confluentinc/kafka-javascript');
+ * const kafka = new Kafka({ 'bootstrap.servers': 'localhost:9092' });
+ * const consumer = kafka.consumer({ 'group.id': 'test-group' });
+ * await consumer.connect();
+ * await consumer.subscribe({ topics: ["test-topic"] });
+ * consumer.run({
+ *   eachMessage: async ({ topic, partition, message }) => { console.log({topic, partition, message}); }
+ * });
+ * @memberof KafkaJS
+ * @see [Consumer example]{@link https://github.com/confluentinc/confluent-kafka-javascript/blob/master/examples/consumer.js}
+ */
 class Consumer {
   /**
    * The config supplied by the user.
@@ -86,7 +112,7 @@ class Consumer {
 
   /**
    * Contains a list of stored topics/regexes that the user has subscribed to.
-   * @type {(string|RegExp)[]}
+   * @type {Array<string|RegExp>}
    */
   #storedSubscriptions = [];
 
@@ -228,14 +254,13 @@ class Consumer {
    */
   #clientName = undefined;
 
-  /**
-   * Convenience function to create the metadata object needed for logging.
-   */
+  // Convenience function to create the metadata object needed for logging.
   #createConsumerBindingMessageMetadata() {
     return createBindingMessageMetadata(this.#clientName);
   }
 
   /**
+   * This method should not be used directly. See {@link KafkaJS.Consumer}.
    * @constructor
    * @param {import("../../types/kafkajs").ConsumerConfig} kJSConfig
    */
@@ -246,6 +271,7 @@ class Consumer {
   /**
    * @returns {import("../rdkafka").Consumer | null} the internal node-rdkafka client.
    * @note only for internal use and subject to API changes.
+   * @private
    */
   _getInternalClient() {
     return this.#internalClient;
@@ -257,7 +283,7 @@ class Consumer {
    * The consumer must be connected before connecting the resulting admin client.
    * The usage of the admin client is limited to the lifetime of the consumer.
    * The consumer's logger is shared with the admin client.
-   * @returns {import("../../types/kafkajs").Admin}
+   * @returns {KafkaJS.Admin}
    */
   dependentAdmin() {
     return new Admin(null, this);
@@ -273,6 +299,7 @@ class Consumer {
    * Clear the message cache, and reset to stored positions.
    *
    * @param {Array<{topic: string, partition: number}>|null} topicPartitions to clear the cache for, if null, then clear all assigned.
+   * @private
    */
   async #clearCacheAndResetPositions() {
     /* Seek to stored offset for each topic partition. It's possible that we've
@@ -325,6 +352,7 @@ class Consumer {
    * Used as a trampoline to the user's rebalance listener, if any.
    * @param {Error} err - error in rebalance
    * @param {import("../../types").TopicPartition[]} assignment
+   * @private
    */
   async #rebalanceCallback(err, assignment) {
     const isLost = this.#internalClient.assignmentLost();
@@ -666,6 +694,7 @@ class Consumer {
   /**
    * Callback for the event.error event, either fails the initial connect(), or logs the error.
    * @param {Error} err
+   * @private
    */
   #errorCb(err) {
     if (this.#state === ConsumerState.CONNECTING) {
@@ -679,6 +708,7 @@ class Consumer {
    * Converts headers returned by node-rdkafka into a format that can be used by the eachMessage/eachBatch callback.
    * @param {import("../..").MessageHeader[] | undefined} messageHeaders
    * @returns {import("../../types/kafkajs").IHeaders}
+   * @private
    */
   #createHeaders(messageHeaders) {
     let headers;
@@ -703,6 +733,7 @@ class Consumer {
    * Converts a message returned by node-rdkafka into a message that can be used by the eachMessage callback.
    * @param {import("../..").Message} message
    * @returns {import("../../types/kafkajs").EachMessagePayload}
+   * @private
    */
   #createPayload(message) {
     let key = message.key;
@@ -739,6 +770,7 @@ class Consumer {
    * @param {*} payload The payload we're creating. This is a method attached to said object.
    * @param {*} offsetToResolve The offset to resolve.
    * @param {*} leaderEpoch The leader epoch of the message (optional). We expect users to provide it, but for API-compatibility reasons, it's optional.
+   * @private
    */
   #eachBatchPayload_resolveOffsets(payload, offsetToResolve, leaderEpoch = -1) {
     const offset = +offsetToResolve;
@@ -773,6 +805,7 @@ class Consumer {
 
   /**
    * Method used by #createBatchPayload to commit offsets.
+   * @private
    */
   async #eachBatchPayload_commitOffsetsIfNecessary() {
     if (this.#autoCommit) {
@@ -785,11 +818,12 @@ class Consumer {
     await this.commitOffsets();
   }
 
-   /**
-    * Request a size increase.
-    * It increases the size by 2x, but only if the size is less than 1024,
-    * only if the size has been requested to be increased twice in a row.
-    */
+  /**
+   * Request a size increase.
+   * It increases the size by 2x, but only if the size is less than 1024,
+   * only if the size has been requested to be increased twice in a row.
+   * @private
+   */
    #increaseMaxSize() {
      if (this.#messageCacheMaxSize === 1024)
          return;
@@ -804,6 +838,7 @@ class Consumer {
    * Request a size decrease.
    * It decreases the size to 80% of the last received size, with a minimum of 1.
    * @param {number} recvdSize - the number of messages received in the last poll.
+   * @private
    */
   #decreaseMaxSize(recvdSize) {
       this.#messageCacheMaxSize = Math.max(Math.floor((recvdSize * 8) / 10), 1);
@@ -814,6 +849,7 @@ class Consumer {
    * Converts a list of messages returned by node-rdkafka into a message that can be used by the eachBatch callback.
    * @param {import("../..").Message[]} messages - must not be empty. Must contain messages from the same topic and partition.
    * @returns {import("../../types/kafkajs").EachBatchPayload}
+   * @private
    */
   #createBatchPayload(messages) {
     const topic = messages[0].topic;
@@ -919,6 +955,7 @@ class Consumer {
    * @param {PerPartitionCache} ppc Per partition cache to use or null|undefined .
    * @returns {Promise<import("../..").Message | null>} a promise that resolves to a single message or null.
    * @note this method caches messages as well, but returns only a single message.
+   * @private
    */
   async #consumeSingleCached(ppc) {
     const msg = this.#messageCache.next(ppc);
@@ -945,6 +982,7 @@ class Consumer {
    * @returns {Promise<import("../..").Message[] | null>} a promise that resolves to a list of messages or null.
    * @note this method caches messages as well.
    * @sa #consumeSingleCached
+   * @private
    */
   async #consumeCachedN(ppc, size) {
     const msgs = this.#messageCache.nextN(ppc, size);
@@ -967,10 +1005,9 @@ class Consumer {
 
   /**
    * Consumes n messages from the internal consumer.
-   * @returns {Promise<import("../..").Message[]>} a promise that resolves to a list of messages.
-   *                                               The size of this list is guaranteed to be less
-   *                                               than or equal to n.
+   * @returns {Promise<import("../..").Message[]>} A promise that resolves to a list of messages. The size of this list is guaranteed to be less than or equal to n.
    * @note this method cannot be used in conjunction with #consumeSingleCached.
+   * @private
    */
   async #consumeN(n) {
     return new Promise((resolve, reject) => {
@@ -986,8 +1023,9 @@ class Consumer {
 
   /**
    * Flattens a list of topics with partitions into a list of topic, partition.
-   * @param {({topic: string, partitions: number[]}|{topic: string, partition: number})[]} topics
+   * @param {Array<({topic: string, partitions: Array<number>}|{topic: string, partition: number})>} topics
    * @returns {import("../../types/rdkafka").TopicPartition[]} a list of (topic, partition).
+   * @private
    */
   #flattenTopicPartitions(topics) {
     const ret = [];
@@ -1008,6 +1046,10 @@ class Consumer {
 
   /**
    * Set up the client and connect to the bootstrap brokers.
+   *
+   * This method can be called only once for a consumer instance, and must be
+   * called before doing any other operations.
+   *
    * @returns {Promise<void>} a promise that resolves when the consumer is connected.
    */
   async connect() {
@@ -1035,7 +1077,10 @@ class Consumer {
 
   /**
    * Subscribes the consumer to the given topics.
-   * @param {import("../../types/kafkajs").ConsumerSubscribeTopics | import("../../types/kafkajs").ConsumerSubscribeTopic} subscription
+   * @param {object} subscription - An object containing the topic(s) to subscribe to - one of `topic` or `topics` must be present.
+   * @param {string?} subscription.topic - The topic to subscribe to.
+   * @param {Array<string>?} subscription.topics - The topics to subscribe to.
+   * @param {boolean?} subscription.replace - Whether to replace the existing subscription, or to add to it. Adds by default.
    */
   async subscribe(subscription) {
     if (this.#state !== ConsumerState.CONNECTED) {
@@ -1090,7 +1135,11 @@ class Consumer {
 
   /**
    * Starts consumer polling. This method returns immediately.
-   * @param {import("../../types/kafkajs").ConsumerRunConfig} config
+   * @param {object} config - The configuration for running the consumer.
+   * @param {function?} config.eachMessage - The function to call for processing each message.
+   * @param {function?} config.eachBatch - The function to call for processing each batch of messages - can only be set if eachMessage is not set.
+   * @param {boolean?} config.eachBatchAutoResolve - Whether to automatically resolve offsets for each batch (only applicable if eachBatch is set, true by default).
+   * @param {number?} config.partitionsConsumedConcurrently - The limit to the number of partitions consumed concurrently (1 by default).
    */
   async run(config) {
     if (this.#state !== ConsumerState.CONNECTED) {
@@ -1136,7 +1185,8 @@ class Consumer {
    *
    * @param m Message as obtained from #consumeSingleCached.
    * @param config Config as passed to run().
-   * @returns {Promise<number>} the cache index of the message that was processed.
+   * @returns {Promise<number>} The cache index of the message that was processed.
+   * @private
    */
   async #messageProcessor(m, config) {
     let ppc;
@@ -1192,10 +1242,12 @@ class Consumer {
   /**
    * Processes a batch of messages.
    *
-   * @param {[[Message], PerPartitionCache]} ms Messages as obtained from #consumeCachedN (ms.length !== 0).
+   * @param {object} ms Messages as obtained from #consumeCachedN (ms.length !== 0).
+   *                    This is of the form [Message[], PerPartitionCache].
    * @param config Config as passed to run().
    * @returns {Promise<PerPartitionCache>} the PPC corresponding to
    *                                       the passed batch.
+   * @private
    */
   async #batchProcessor(ms, config) {
     let ppc;
@@ -1325,6 +1377,7 @@ class Consumer {
    *  4. Some other worker has started terminating.
    *
    * Worker termination acts as a async barrier.
+   * @private
    */
   async #worker(config, perMessageProcessor, fetcher) {
     let ppc = null;
@@ -1379,6 +1432,7 @@ class Consumer {
    * After that it waits until barrier is reached or
    * max poll interval is reached. In the latter case it
    * marks the batch payloads as stale.
+   * @private
    */
   async #cacheExpirationLoop() {
     while (!this.#workerTerminationScheduled.resolved) {
@@ -1406,6 +1460,7 @@ class Consumer {
 
   /**
    * Executes all pending operations and clears the list.
+   * @private
    */
   async #executePendingOperations() {
     for (const op of this.#pendingOperations) {
@@ -1417,6 +1472,7 @@ class Consumer {
   /**
    * Internal polling loop.
    * Spawns and awaits workers until disconnect is initiated.
+   * @private
    */
   async #runInternal(config) {
     this.#concurrency = config.partitionsConsumedConcurrently;
@@ -1471,6 +1527,7 @@ class Consumer {
    * @param {any} args
    * @param {number} args.timeout - the timeout in milliseconds, defaults to 1000.
    * @returns {import("../..").Message|null} a message, or null if the timeout was reached.
+   * @private
    */
   async consume({ timeout } = { timeout: 1000 }) {
     if (this.#state !== ConsumerState.CONNECTED) {
@@ -1507,8 +1564,8 @@ class Consumer {
 
   /**
    * Commit offsets for the given topic partitions. If topic partitions are not specified, commits all offsets.
-   * @param {import("../../types/kafkajs").TopicPartitionOffset[]?} topicPartitions
-   * @returns {Promise<void>} a promise that resolves when the offsets have been committed.
+   * @param {Array<{topic: string, partition: number, offset: string, leaderEpoch: number|null, metadata: string|null}>?} topicPartitions
+   * @returns {Promise<void>} A promise that resolves when the offsets have been committed.
    */
   async commitOffsets(topicPartitions = null) {
     if (this.#state !== ConsumerState.CONNECTED) {
@@ -1541,10 +1598,10 @@ class Consumer {
   /**
    * Fetch committed offsets for the given topic partitions.
    *
-   * @param {import("../../types/kafkajs").TopicPartitionOffsetAndMetadata[]} topicPartitions -
-   *        the topic partitions to check for committed offsets. Defaults to all assigned partitions.
-   * @param {number} timeout - timeout in ms. Defaults to infinite (-1).
-   * @returns {Promise<import("../../types/kafkajs").TopicPartitionOffsetAndMetadata[]>} a promise that resolves to the committed offsets.
+   * @param {Array<{topic: string, partition: number}>?} topicPartitions -
+   *        The topic partitions to check for committed offsets. Defaults to all assigned partitions.
+   * @param {number} timeout - Timeout in ms. Defaults to infinite (-1).
+   * @returns {Promise<Array<{topic: string, partition: number, offset: string, leaderEpoch: number|null, metadata: string|null}>>} A promise that resolves to the committed offsets.
    */
   async committed(topicPartitions = null, timeout = -1) {
     if (this.#state !== ConsumerState.CONNECTED) {
@@ -1571,8 +1628,9 @@ class Consumer {
 
   /**
    * Apply pending seeks to topic partitions we have just obtained as a result of a rebalance.
-   * @param {{topic: string, partition: number}[]} assignment The list of topic partitions to check for pending seeks.
-   * @returns {{topic: string, partition: number, offset: number}[]} the new assignment with the offsets seeked to, which can be passed to assign().
+   * @param {Array<{topic: string, partition: number}>} assignment The list of topic partitions to check for pending seeks.
+   * @returns {Array<{topic: string, partition: number, offset: number}>} The new assignment with the offsets seeked to, which can be passed to assign().
+   * @private
    */
   #assignAsPerSeekedOffsets(assignment) {
     for (let i = 0; i < assignment.length; i++) {
@@ -1698,12 +1756,21 @@ class Consumer {
   }
 
   /**
-   * Seek to the given offset for the topic partition.
+   * Seek to the given offset for a topic partition.
+   *
    * This method is completely asynchronous, and does not wait for the seek to complete.
    * In case any partitions that are seeked to, are not a part of the current assignment, they are stored internally.
-   * If at any time, the consumer is assigned the partition, the seek will be performed.
-   * Depending on the value of the librdkafka property 'enable.auto.commit', the consumer will commit the offset seeked to.
-   * @param {import("../../types/kafkajs").TopicPartitionOffset} topicPartitionOffset
+   *
+   * If at any later time, the consumer is assigned the partition, as a part of a rebalance,
+   * the pending seek will be performed.
+   *
+   * Additionally, if the librdkafka property 'enable.auto.commit' or kafkaJS.autoCommit is true,
+   * the consumer will commit the offset seeked.
+   *
+   * @param {object} topicPartitionOffset
+   * @param {string} topicPartitionOffset.topic
+   * @param {number} topicPartitionOffset.partition
+   * @param {string} topicPartitionOffset.offset - The offset to seek to.
    */
   seek(topicPartitionOffset) {
     if (this.#state !== ConsumerState.CONNECTED) {
@@ -1734,7 +1801,7 @@ class Consumer {
 
   /**
    * Find the assigned topic partitions for the consumer.
-   * @returns {import("../../types/kafkajs").TopicPartition[]} the current assignment.
+   * @returns {Array<{topic: string, partitions: Array<number>}>} the current assignment.
    */
   assignment() {
     if (this.#state !== ConsumerState.CONNECTED) {
@@ -1747,7 +1814,7 @@ class Consumer {
   /**
    * Get the type of rebalance protocol used in the consumer group.
    *
-   * @returns "NONE" (if not in a group yet), "COOPERATIVE" or "EAGER".
+   * @returns {string} "NONE" (if not in a group yet), "COOPERATIVE" or "EAGER".
    */
   rebalanceProtocol() {
     if (this.#state !== ConsumerState.CONNECTED) {
@@ -1759,7 +1826,8 @@ class Consumer {
   /**
    * Fetches all partitions of topic that are assigned to this consumer.
    * @param {string} topic
-   * @returns {number[]} a list of partitions.
+   * @returns {Array<number>} A list of partitions.
+   * @private
    */
   #getAllAssignedPartition(topic) {
     return this.#internalClient.assignments()
@@ -1769,10 +1837,12 @@ class Consumer {
 
   /**
    * Pauses the given topic partitions. If partitions are not specified, pauses
-   * all partitions for the given topic. If topic partition(s) are already paused
-   * this method has no effect.
-   * @param {{topic: string, partitions?: number[]}[]} topics
-   * @returns {Function} a function that can be called to resume the given topic partitions.
+   * all partitions for the given topic.
+   *
+   * If topic partition(s) are already paused this method has no effect.
+   *
+   * @param {Array<{topic: string, partitions: Array<number>|null}>} topics - Topics or topic partitions to pause.
+   * @returns {function} A function that can be called to resume the topic partitions paused by this call.
    */
   pause(topics) {
     if (this.#state !== ConsumerState.CONNECTED) {
@@ -1821,7 +1891,7 @@ class Consumer {
 
   /**
    * Returns the list of paused topic partitions.
-   * @returns {{topic: string, partitions: number[]}[]} a list of paused topic partitions.
+   * @returns {Array<{topic: string, partitions: Array<number>}>} A list of paused topic partitions.
    */
   paused() {
     const topicToPartitions = Array
@@ -1841,9 +1911,10 @@ class Consumer {
 
   /**
    * Resumes the given topic partitions. If partitions are not specified, resumes
-   * all partitions for the given topic. If topic partition(s) are already resumed
-   * this method has no effect.
-   * @param {{topic: string, partitions?: number[]}[]} topics
+   * all partitions for the given topic.
+   *
+   * If topic partition(s) are already resumed this method has no effect.
+   * @param {Array<{topic: string, partitions: Array<number>|null}>} topics - Topics or topic partitions to resume.
    */
   resume(topics) {
     if (this.#state !== ConsumerState.CONNECTED) {
@@ -1884,7 +1955,14 @@ class Consumer {
   }
 
   /**
-   * @returns {import("../../types/kafkajs").Logger} the logger associated to this consumer.
+   * Get the logger associated to this consumer instance.
+   *
+   * @example
+   * const logger = consumer.logger();
+   * logger.info('Hello world');
+   * logger.setLogLevel(logLevel.ERROR);
+   * @see {@link KafkaJS.logLevel} for available log levels
+   * @returns {Object} The logger instance.
    */
   logger() {
     return this.#logger;
@@ -1897,8 +1975,10 @@ class Consumer {
 
   /**
    * Disconnects and cleans up the consumer.
-   * @note This cannot be called from within `eachMessage` callback of `Consumer.run`.
-   * @returns {Promise<void>} a promise that resolves when the consumer has disconnected.
+   *
+   * Warning: This cannot be called from within `eachMessage` or `eachBatch` callback of
+   * [Consumer.run]{@link KafkaJS.Consumer#run}.
+   * @returns {Promise<void>} A promise that resolves when the consumer has disconnected.
    */
   async disconnect() {
     /* Not yet connected - no error. */
@@ -1942,4 +2022,4 @@ class Consumer {
   }
 }
 
-module.exports = { Consumer, PartitionAssigners, };
+module.exports = { Consumer, PartitionAssigners: Object.freeze(PartitionAssigners), };

--- a/lib/kafkajs/_consumer_cache.js
+++ b/lib/kafkajs/_consumer_cache.js
@@ -5,6 +5,7 @@ const { LinkedList } = require('./_linked-list');
 
 /**
  * A PerPartitionMessageCache is a cache for messages for a single partition.
+ * @private
  */
 class PerPartitionMessageCache {
     /* The cache is a list of messages. */
@@ -62,6 +63,7 @@ class PerPartitionMessageCache {
 /**
  * MessageCache defines a dynamically sized cache for messages.
  * Internally, it uses PerPartitionMessageCache to store messages for each partition.
+ * @private
  */
 class MessageCache {
     #size;

--- a/lib/kafkajs/_error.js
+++ b/lib/kafkajs/_error.js
@@ -1,10 +1,14 @@
 const LibrdKafkaError = require('../error');
 
 /**
- * @typedef {Object} KafkaJSError represents an error when using the promisified interface.
+ * KafkaJSError represents an error when using the promisified interface.
+ * @memberof KafkaJS
  */
 class KafkaJSError extends Error {
     /**
+     * This constructor is meant to be used by the library. Please see the members for more information on
+     * what can be accessed from an error object.
+     *
      * @param {Error | string} error an Error or a string describing the error.
      * @param {object} properties a set of optional error properties.
      * @param {boolean} [properties.retriable=false] whether the error is retriable. Applies only to the transactional producer
@@ -15,14 +19,44 @@ class KafkaJSError extends Error {
      */
     constructor(e, { retriable = false, fatal = false, abortable = false, stack = null, code = LibrdKafkaError.codes.ERR_UNKNOWN } = {}) {
         super(e, {});
+        /**
+         * Name of the error.
+         * @type {string}
+         */
         this.name = 'KafkaJSError';
+        /**
+         * Message detailing the error.
+         * @type {string}
+         */
         this.message = e.message || e;
+        /**
+         * Whether the error is retriable (for transactional producer).
+         * @type {boolean}
+         */
         this.retriable = retriable;
+        /**
+         * Whether the error is fatal (for transactional producer).
+         * @type {boolean}
+         */
         this.fatal = fatal;
+        /**
+         * Whether the error is abortable (for transactional producer).
+         * @type {boolean}
+         */
         this.abortable = abortable;
+        /**
+         * The error code from Librdkafka.
+         *
+         * This field should be checked (as opposed to the type of the error) to determine what sort of an error this is.
+         * @see {@link RdKafka.LibrdKafkaError.codes} For a list of error codes that can be returned.
+         * @type {number}
+         */
         this.code = code;
 
         if (stack) {
+            /**
+             * The stack trace of the error.
+             */
             this.stack = stack;
         } else {
             Error.captureStackTrace(this, this.constructor);
@@ -41,7 +75,9 @@ class KafkaJSError extends Error {
 }
 
 /**
- * @typedef {Object} KafkaJSProtocolError represents an error that is caused when a Kafka Protocol RPC has an embedded error.
+ * KafkaJSProtocolError represents an error that is caused when a Kafka Protocol RPC has an embedded error.
+ * @extends KafkaJS.KafkaJSError
+ * @memberof KafkaJS
  */
 class KafkaJSProtocolError extends KafkaJSError {
     constructor() {
@@ -51,7 +87,9 @@ class KafkaJSProtocolError extends KafkaJSError {
 }
 
 /**
- * @typedef {Object} KafkaJSOffsetOutOfRange represents the error raised when fetching from an offset out of range.
+ * KafkaJSOffsetOutOfRange represents the error raised when fetching from an offset out of range.
+ * @extends KafkaJS.KafkaJSProtocolError
+ * @memberof KafkaJS
  */
 class KafkaJSOffsetOutOfRange extends KafkaJSProtocolError {
     constructor() {
@@ -61,7 +99,9 @@ class KafkaJSOffsetOutOfRange extends KafkaJSProtocolError {
 }
 
 /**
- * @typedef {Object} KafkaJSConnectionError represents the error raised when a connection to a broker cannot be established or is broken unexpectedly.
+ * KafkaJSConnectionError represents the error raised when a connection to a broker cannot be established or is broken unexpectedly.
+ * @extends KafkaJS.KafkaJSError
+ * @memberof KafkaJS
  */
 class KafkaJSConnectionError extends KafkaJSError {
     constructor() {
@@ -71,7 +111,9 @@ class KafkaJSConnectionError extends KafkaJSError {
 }
 
 /**
- * @typedef {Object} KafkaJSRequestTimeoutError represents the error raised on a timeout for one request.
+ * KafkaJSRequestTimeoutError represents the error raised on a timeout for one request.
+ * @extends KafkaJS.KafkaJSError
+ * @memberof KafkaJS
  */
 class KafkaJSRequestTimeoutError extends KafkaJSError {
     constructor() {
@@ -81,7 +123,9 @@ class KafkaJSRequestTimeoutError extends KafkaJSError {
 }
 
 /**
- * @typedef {Object} KafkaJSPartialMessageError represents the error raised when a response does not contain all expected information.
+ * KafkaJSPartialMessageError represents the error raised when a response does not contain all expected information.
+ * @extends KafkaJS.KafkaJSError
+ * @memberof KafkaJS
  */
 class KafkaJSPartialMessageError extends KafkaJSError {
     constructor() {
@@ -91,7 +135,9 @@ class KafkaJSPartialMessageError extends KafkaJSError {
 }
 
 /**
- * @typedef {Object} KafkaJSSASLAuthenticationError represents an error raised when authentication fails.
+ * KafkaJSSASLAuthenticationError represents an error raised when authentication fails.
+ * @extends KafkaJS.KafkaJSError
+ * @memberof KafkaJS
  */
 class KafkaJSSASLAuthenticationError extends KafkaJSError {
     constructor() {
@@ -101,7 +147,9 @@ class KafkaJSSASLAuthenticationError extends KafkaJSError {
 }
 
 /**
- * @typedef {Object} KafkaJSGroupCoordinatorNotFound represents an error raised when the group coordinator is not found.
+ * KafkaJSGroupCoordinatorNotFound represents an error raised when the group coordinator is not found.
+ * @extends KafkaJS.KafkaJSError
+ * @memberof KafkaJS
  */
 class KafkaJSGroupCoordinatorNotFound extends KafkaJSError {
     constructor() {
@@ -111,7 +159,9 @@ class KafkaJSGroupCoordinatorNotFound extends KafkaJSError {
 }
 
 /**
- * @typedef {Object} KafkaJSNotImplemented represents an error raised when a feature is not implemented for this particular client.
+ * KafkaJSNotImplemented represents an error raised when a feature is not implemented for this particular client.
+ * @extends KafkaJS.KafkaJSError
+ * @memberof KafkaJS
  */
 class KafkaJSNotImplemented extends KafkaJSError {
     constructor() {
@@ -121,7 +171,9 @@ class KafkaJSNotImplemented extends KafkaJSError {
 }
 
 /**
- * @typedef {Object} KafkaJSTimeout represents an error raised when a timeout for an operation occurs (including retries).
+ * KafkaJSTimeout represents an error raised when a timeout for an operation occurs (including retries).
+ * @extends KafkaJS.KafkaJSError
+ * @memberof KafkaJS
  */
 class KafkaJSTimeout extends KafkaJSError {
     constructor() {
@@ -129,7 +181,6 @@ class KafkaJSTimeout extends KafkaJSError {
         this.name = 'KafkaJSTimeout';
     }
 }
-
 class KafkaJSLockTimeout extends KafkaJSTimeout {
     constructor() {
         super(...arguments);
@@ -138,18 +189,26 @@ class KafkaJSLockTimeout extends KafkaJSTimeout {
 }
 
 /**
- * @typedef {Object} KafkaJSAggregateError represents an error raised when multiple errors occur at once.
+ * KafkaJSAggregateError represents an error raised when multiple errors occur at once.
+ * @extends Error
+ * @memberof KafkaJS
  */
 class KafkaJSAggregateError extends Error {
     constructor(message, errors) {
         super(message);
+        /**
+         * A list of errors that are part of the aggregate error.
+         * @type {Array<KafkaJS.KafkaJSError>}
+         */
         this.errors = errors;
         this.name = 'KafkaJSAggregateError';
     }
 }
 
 /**
- * @typedef {Object} KafkaJSNoBrokerAvailableError represents an error raised when no broker is available for the operation.
+ * KafkaJSNoBrokerAvailableError represents an error raised when no broker is available for the operation.
+ * @extends KafkaJS.KafkaJSError
+ * @memberof KafkaJS
  */
 class KafkaJSNoBrokerAvailableError extends KafkaJSError {
     constructor() {
@@ -160,8 +219,9 @@ class KafkaJSNoBrokerAvailableError extends KafkaJSError {
 
 /**
  * @function isRebalancing
- * @param {KafkaJSError} e
- * @returns boolean representing whether the error is a rebalancing error.
+ * @param {KafkaJS.KafkaJSError} e
+ * @returns {boolean} Returns whether the error is a rebalancing error.
+ * @memberof KafkaJS
  */
 const isRebalancing = e =>
     e.type === 'REBALANCE_IN_PROGRESS' ||
@@ -171,7 +231,8 @@ const isRebalancing = e =>
 /**
  * @function isKafkaJSError
  * @param {any} e
- * @returns boolean representing whether the error is a KafkaJSError.
+ * @returns {boolean} Returns whether the error is a KafkaJSError.
+ * @memberof KafkaJS
  */
 const isKafkaJSError = e => e instanceof KafkaJSError;
 

--- a/lib/kafkajs/_kafka.js
+++ b/lib/kafkajs/_kafka.js
@@ -4,13 +4,25 @@ const { Admin, ConsumerGroupStates, AclOperationTypes } = require('./_admin');
 const error = require('./_error');
 const { logLevel, checkIfKafkaJsKeysPresent, CompatibilityErrorMessages } = require('./_common');
 
+/**
+ * This class holds common configuration for clients, and an instance can be
+ * used to create producers, consumers, or admin clients.
+ * @memberof KafkaJS
+ */
 class Kafka {
-  /* @type{import("../../types/kafkajs").CommonConstructorConfig} */
+  /** @type{import("../../types/kafkajs").CommonConstructorConfig} */
   #commonClientConfig = {};
 
   /**
+   * The configuration provided will be shared across all clients created using
+   * this Kafka object.
    *
-   * @param {import("../../types/kafkajs").CommonConstructorConfig} config
+   * Properties listed within [CONFIGURATION.md]{@link https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md}
+   * can be used as keys for this object.
+   *
+   * A number of KafkaJS-compatible configuration options can be provided as an object
+   * with the `kafkaJS` key as illustrated in [MIGRATION.md]{@link https://github.com/confluentinc/confluent-kafka-javascript/blob/dev_early_access_development_branch/MIGRATION.md}.
+   * @param {object} config - The common configuration for all clients created using this Kafka object.
    */
   constructor(config) {
     this.#commonClientConfig = config ?? {};
@@ -25,6 +37,7 @@ class Kafka {
    * Merge the producer/consumer specific configuration with the common configuration.
    * @param {import("../../types/kafkajs").ProducerConstructorConfig|import("../../types/kafkajs").ConsumerConstructorConfig} config
    * @returns {(import("../../types/kafkajs").ProducerConstructorConfig & import("../../types/kafkajs").CommonConstructorConfig) | (import("../../types/kafkajs").ConsumerConstructorConfig & import("../../types/kafkajs").CommonConstructorConfig)}
+   * @private
    */
   #mergeConfiguration(config) {
     config = Object.assign({}, config) ?? {};
@@ -44,8 +57,13 @@ class Kafka {
 
   /**
    * Creates a new producer.
-   * @param {import("../../types/kafkajs").ProducerConstructorConfig} config
-   * @returns {Producer}
+   *
+   * An object containing the configuration for the producer to be created. This
+   * will be merged with the common configuration provided when creating the
+   * {@link RdKafka.Kafka} object, and the same set of keys can be used.
+   *
+   * @param {object} config - The configuration for the producer to be created.
+   * @returns {KafkaJS.Producer}
    */
   producer(config) {
     const disallowedKey = checkIfKafkaJsKeysPresent('producer', config ?? {});
@@ -58,8 +76,13 @@ class Kafka {
 
   /**
    * Creates a new consumer.
-   * @param {import("../../types/kafkajs").ConsumerConstructorConfig} config
-   * @returns {Consumer}
+   *
+   * An object containing the configuration for the consumer to be created. This
+   * will be merged with the common configuration provided when creating the
+   * {@link RdKafka.Kafka} object, and the same set of keys can be used.
+   *
+   * @param {object} config - The configuration for the consumer to be created.
+   * @returns {KafkaJS.Consumer}
    */
   consumer(config) {
     const disallowedKey = checkIfKafkaJsKeysPresent('consumer', config ?? {});
@@ -70,6 +93,16 @@ class Kafka {
     return new Consumer(this.#mergeConfiguration(config));
   }
 
+  /**
+   * Creates a new admin client.
+   *
+   * An object containing the configuration for the admin client to be created. This
+   * will be merged with the common configuration provided when creating the
+   * {@link RdKafka.Kafka} object, and the same set of keys can be used.
+   *
+   * @param {object} config - The configuration for the admin client to be created.
+   * @returns {KafkaJS.Admin}
+   */
   admin(config) {
     const disallowedKey = checkIfKafkaJsKeysPresent('admin', config ?? {});
     if (disallowedKey !== null) {

--- a/lib/kafkajs/_linked-list.js
+++ b/lib/kafkajs/_linked-list.js
@@ -1,6 +1,7 @@
 /**
  * Node class for linked list, after being removed
  * it cannot be used again.
+ * @private
  */
 class LinkedListNode {
     // Value contained by the node.

--- a/lib/kafkajs/_producer.js
+++ b/lib/kafkajs/_producer.js
@@ -25,14 +25,39 @@ const ProducerState = Object.freeze({
   DISCONNECTED: 6,
 });
 
-const CompressionTypes = Object.freeze({
+/**
+ * A list of supported compression types.
+ * @enum {string}
+ * @readonly
+ * @memberof KafkaJS
+ */
+const CompressionTypes = {
   None: 'none',
   GZIP: 'gzip',
   SNAPPY: 'snappy',
   LZ4: 'lz4',
   ZSTD: 'zstd',
-});
+};
 
+/**
+ * Producer for sending messages to Kafka (promise-based, async API).
+ *
+ * The producer allows sending messages to the Kafka cluster, and provides
+ * methods to configure and control various aspects of that. This class should
+ * not be instantiated directly, and rather, an instance of
+ * [Kafka]{@link KafkaJS.Kafka} should be used.
+ *
+ * @example
+ * const { Kafka } = require('@confluentinc/kafka-javascript');
+ * const kafka = new Kafka({ 'bootstrap.servers': 'localhost:9092' });
+ * const producer = kafka.producer();
+ * await producer.connect();
+ * await producer.send({
+ *   // send options
+ * });
+ * @memberof KafkaJS
+ * @see [Producer example]{@link https://github.com/confluentinc/confluent-kafka-javascript/blob/master/examples/producer.js}
+ */
 class Producer {
   /**
    * The config supplied by the user.
@@ -77,6 +102,7 @@ class Producer {
   #logger = new DefaultLogger();
 
   /**
+   * This method should not be used directly. See {@link KafkaJS.Producer}.
    * @constructor
    * @param {import("../../types/kafkajs").ProducerConfig} kJSConfig
    */
@@ -87,6 +113,7 @@ class Producer {
   /**
    * @returns {import("../rdkafka").Producer | null} the internal node-rdkafka client.
    * @note only for internal use and subject to API changes.
+   * @private
    */
   _getInternalClient() {
     return this.#internalClient;
@@ -98,7 +125,7 @@ class Producer {
    * The producer must be connected before connecting the resulting admin client.
    * The usage of the admin client is limited to the lifetime of the producer.
    * The producer's logger is shared with the admin client.
-   * @returns {import("../../types/kafkajs").Admin}
+   * @returns {KafkaJS.Admin}
    */
   dependentAdmin() {
     return new Admin(null, this);
@@ -111,9 +138,7 @@ class Producer {
    */
   #clientName = undefined;
 
-  /**
-   * Convenience function to create the metadata object needed for logging.
-   */
+  // Convenience function to create the metadata object needed for logging.
   #createProducerBindingMessageMetadata() {
     return createBindingMessageMetadata(this.#clientName);
   }
@@ -244,6 +269,7 @@ class Producer {
    * Flattens a list of topics with partitions into a list of topic, partition, offset.
    * @param {import("../../types/kafkajs").TopicOffsets[]} topics
    * @returns {import("../../types/kafkajs").TopicPartitionOffset}
+   * @private
    */
   #flattenTopicPartitionOffsets(topics) {
     return topics.flatMap(topic => {
@@ -273,6 +299,7 @@ class Producer {
    * Processes a delivery report, converting it to the type that the promisified API uses.
    * @param {import('../..').LibrdKafkaError} err
    * @param {import('../..').DeliveryReport} report
+   * @private
    */
   #deliveryCallback(err, report) {
     const opaque = report.opaque;
@@ -328,6 +355,7 @@ class Producer {
   /**
    * Callback for the event.error event, either fails the initial connect(), or logs the error.
    * @param {Error} err
+   * @private
    */
   #errorCb(err) {
     if (this.#state === ProducerState.CONNECTING) {
@@ -339,6 +367,9 @@ class Producer {
 
   /**
    * Set up the client and connect to the bootstrap brokers.
+   *
+   * This method can be called only once for a producer instance, and must be
+   * called before doing any other operations.
    * @returns {Promise<void>} Resolves when connection is complete, rejects on error.
    */
   async connect() {
@@ -399,8 +430,15 @@ class Producer {
   }
 
   /**
-   * Start a transaction - can only be used with a transactional producer.
-   * @returns {Promise<Producer>} Resolves with the producer when the transaction is started.
+   * Starts a new transaction.
+   *
+   * This can only be used with a transactional producer, where the transactional
+   * ID is set within the config.
+   *
+   * No more than one transaction may be ongoing at a time.
+   * @sa {@link KafkaJS.Producer#commit}
+   * @sa {@link KafkaJS.Producer#abort}
+   * @returns {Promise<KafkaJS.Producer>} Resolves with the producer when the transaction is started.
    */
   async transaction() {
     if (this.#state !== ProducerState.CONNECTED) {
@@ -430,6 +468,8 @@ class Producer {
 
   /**
    * Commit the current transaction.
+   *
+   * Can only be called if there is an ongoing transaction.
    * @returns {Promise<void>} Resolves when the transaction is committed.
    */
   async commit() {
@@ -457,6 +497,8 @@ class Producer {
 
   /**
    * Abort the current transaction.
+   *
+   * Can only be called if there is an ongoing transaction.
    * @returns {Promise<void>} Resolves when the transaction is aborted.
    */
   async abort() {
@@ -484,9 +526,11 @@ class Producer {
 
   /**
    * Send offsets for the transaction.
+   *
+   * Can only be called if there is an ongoing transaction.
    * @param {object} arg - The arguments to sendOffsets
-   * @param {Consumer} arg.consumer - The consumer to send offsets for.
-   * @param {import("../../types/kafkajs").TopicOffsets[]} arg.topics - The topics, partitions and the offsets to send.
+   * @param {KafkaJS.Consumer} arg.consumer - The consumer to send offsets for.
+   * @param {Array<{topic: string, partitions: Array<{partition: number, offset: string}>}>} arg.topics - The topics, partitions and the offsets to send.
    *
    * @returns {Promise<void>} Resolves when the offsets are sent.
    */
@@ -526,8 +570,8 @@ class Producer {
   /**
    * Check if there is an ongoing transaction.
    *
-   * NOTE: Since Producer itself represents a transaction, and there is no distinct
-   *       type for a transaction, this method exists on the producer.
+   * Since a producer itself represents a transaction, and there is no distinct
+   * type for a transaction, this method exists on the producer.
    * @returns {boolean} true if there is an ongoing transaction, false otherwise.
    */
   isActive() {
@@ -537,8 +581,13 @@ class Producer {
   /**
    * Sends a record of messages to a specific topic.
    *
-   * @param {import('../../types/kafkajs').ProducerRecord} sendOptions - The record to send. The keys `acks`, `timeout`, and `compression` are not used, and should not be set, rather, they should be set in the global config.
-   * @returns {Promise<import("../../types/kafkajs").RecordMetadata[]>} Resolves with the record metadata for the messages.
+   * @example
+   * const deliveryReport = await producer.send({
+   *   topic: 'test-topic',
+   *   messages: [{ value: 'v1', partition: 0, key: 'x' }]
+   * });
+   * @param {Object} sendOptions - The record to send. The keys `acks`, `timeout`, and `compression` are not used, and should not be set, rather, they should be set in the global config.
+   * @returns {Promise<Array<Object>>} Resolves with the record metadata for the messages.
    */
   async send(sendOptions) {
     if (this.#state !== ProducerState.CONNECTED) {
@@ -624,9 +673,17 @@ class Producer {
   /**
     * Sends a record of messages to various topics.
     *
-    * NOTE: This method is identical to calling send() repeatedly and waiting on all the return values together.
-    * @param {import('../../types/kafkajs').ProducerBatch} sendOptions - The record to send. The keys `acks`, `timeout`, and `compression` are not used, and should not be set, rather, they should be set in the global config.
-    * @returns {Promise<import("../../types/kafkajs").RecordMetadata[]>} Resolves with the record metadata for the messages.
+    * This method is identical to calling send() repeatedly and waiting on all the return values together.
+    *
+    * @example
+    * const deliveryReports = await producer.sendBatch({
+    *   topicMessages: [
+    *     { topic: 'test-topic1', messages: [{ key: 'hello', value: 'hello' }] },
+    *     { topic: 'test-topic2', messages: [{ key: 'world', value: 'world' }] }
+    *   ]
+    * });
+    * @param {Object} sendOptions - The record to send. The keys `acks`, `timeout`, and `compression` are not used, and should not be set, rather, they should be set in the global config.
+    * @returns {Promise<Array<Object>>} Resolves with the record metadata for the messages.
   */
   async sendBatch(sendOptions) {
     if (this.#state !== ProducerState.CONNECTED) {
@@ -667,7 +724,14 @@ class Producer {
   }
 
   /**
-   * @returns {import("../../types/kafkajs").Logger} the logger associated to this producer.
+   * Get the logger associated to this producer instance.
+   *
+   * @example
+   * const logger = producer.logger();
+   * logger.info('Hello world');
+   * logger.setLogLevel(logLevel.ERROR);
+   * @see {@link KafkaJS.logLevel} for available log levels
+   * @returns {Object} The logger instance.
    */
   logger() {
     return this.#logger;
@@ -676,9 +740,10 @@ class Producer {
   /**
    * Change SASL credentials to be sent on the next authentication attempt.
    *
-   * @param {string} args.username
-   * @param {string} args.password
-   * @note Only applicable if SASL authentication is being used.
+   * Only applicable if SASL authentication is being used.
+   * @param {object} args The SASL credentials to set.
+   * @param {string} args.username SASL username.
+   * @param {string} args.password SASL password.
    */
   setSaslCredentials(args = {}) {
     if (!Object.hasOwn(args, 'username')) {
@@ -715,22 +780,27 @@ class Producer {
    * size. Calling flush sends any pending messages immediately without
    * waiting for this size or timeout.
    *
-   * @param {number} args.timeout Time to try flushing for in milliseconds.
+   * This is only useful when using asynchronous sends.
+   * For example, the following code does not get any benefit from flushing,
+   * since `await`ing the send waits for the delivery report, and the message
+   * has already been sent by the time we start flushing:
+   *
+   * ```js
+   * for (let i = 0; i < 100; i++) await send(...);
+   * await flush(...) // Not useful.
+   * ```
+   *
+   * However, using the following code may put these 5 messages into a batch
+   * and then the subsequent `flush` will send the batch altogether (as long as
+   * batch size, etc. are conducive to batching):
+   * ```js
+   * for (let i = 0; i < 5; i++) send(...);
+   * await flush({timeout: 5000});
+   * ```
+   * @param {object} args
+   * @param {number} args.timeout Time to try flushing for in milliseconds, 500ms by default.
    * @returns {Promise<void>} Resolves on successful flush.
    * @throws {KafkaJSTimeout} if the flush times out.
-   *
-   * @note This is only useful when using asynchronous sends.
-   *       For example, the following code does not get any benefit from flushing,
-   *       since `await`ing the send waits for the delivery report, and the message
-   *       has already been sent by the time we start flushing:
-   *         for (let i = 0; i < 100; i++) await send(...);
-   *         await flush(...) // Not useful.
-   *
-   *       However, using the following code may put these 5 messages into a batch
-   *       and then the subsequent `flush` will send the batch altogether (as long as
-   *       batch size, etc. are conducive to batching):
-   *         for (let i = 0; i < 5; i++) send(...);
-   *         await flush({timeout: 5000});
    */
   async flush(args = { timeout: 500 }) {
     if (this.#state !== ProducerState.CONNECTED) {
@@ -764,4 +834,4 @@ class Producer {
   }
 }
 
-module.exports = { Producer, CompressionTypes };
+module.exports = { Producer, CompressionTypes: Object.freeze(CompressionTypes) };

--- a/lib/kafkajs/index.js
+++ b/lib/kafkajs/index.js
@@ -1,1 +1,5 @@
+/**
+ * Namespace for promifisied, async Kafka client API.
+ * @namespace KafkaJS
+ */
 module.exports = require("./_kafka");

--- a/lib/producer-stream.js
+++ b/lib/producer-stream.js
@@ -31,11 +31,38 @@ util.inherits(ProducerStream, Writable);
  *
  * This stream does not operate in Object mode and can only be given buffers.
  *
- * @param {Producer} producer - The Kafka Producer object.
- * @param {array} topics - Array of topics
+ * Do not instantiate this directly, instead, use the {@link RdKafka.Producer.createWriteStream} method.
+ *
+ * @example
+ * // This call returns a new writable stream to our topic 'topic-name'
+ * const stream = Kafka.Producer.createWriteStream({
+ *   'bootstrap.servers': 'localhost:9092'
+ * }, {}, {
+ *   topic: 'topic-name'
+ * });
+ *
+ * // Writes a message to the stream
+ * const queuedSuccess = stream.write(Buffer.from('Awesome message'));
+ *
+ * if (!queuedSuccess) {
+ *   // Note that this only tells us if the stream's queue is full,
+ *   // it does not tell us if there was an error getting the message to the
+ *   // cluster.
+ *   console.log('Too many messages in our queue already, retry later.');
+ * }
+ *
+ * // It is necessary to listen to errors.
+ * // Otherwise, any error will bubble up as an uncaught exception.
+ * stream.on('error', (err) => {
+ *   console.error('Error in our kafka stream');
+ * });
+ *
+ * @param {RdKafka.Producer} producer - The Kafka Producer object.
+ * @param {array} topics - Array of topics.
  * @param {object} options - Topic configuration.
  * @constructor
  * @extends stream.Writable
+ * @memberof RdKafka
  */
 function ProducerStream(producer, options) {
   if (!(this instanceof ProducerStream)) {
@@ -275,6 +302,12 @@ ProducerStream.prototype._writev = function(data, cb) {
 
 };
 
+/**
+ * Close the ProducerStream.
+ *
+ * This disconnects the underlying producer if required and closes the stream.
+ * @param {function} cb - Callback to fire when the stream is closed.
+ */
 ProducerStream.prototype.close = function(cb) {
   var self = this;
   if (cb) {

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -33,11 +33,16 @@ util.inherits(Producer, Client);
  * the connection will by brought down by using poll, which automatically
  * runs when a transaction is made on the object.
  *
+ * Methods on a Producer will throw a [LibrdKafkaError]{@link RdKafka.LibrdKafkaError}
+ * on failure.
+ *
  * @param {object} conf - Key value pairs to configure the producer
- * @param {object} topicConf - Key value pairs to create a default
- * topic configuration
- * @extends Client
+ * @param {object?} topicConf - Key value pairs to create a default
+ *                              topic configuration
+ * @extends RdKafka.Client
  * @constructor
+ * @memberof RdKafka
+ * @see [Producer example]{@link https://github.com/confluentinc/confluent-kafka-javascript/blob/master/examples/node-rdkafka/producer.md}
  */
 function Producer(conf, topicConf) {
   if (!(this instanceof Producer)) {
@@ -102,13 +107,15 @@ function Producer(conf, topicConf) {
 }
 
 /**
- * Produce a message to Kafka synchronously.
+ * Produce a message to Kafka asynchronously.
  *
  * This is the method mainly used in this class. Use it to produce
  * a message to Kafka.
  *
- * When this is sent off, there is no guarantee it is delivered. If you need
- * guaranteed delivery, change your *acks* settings, or use delivery reports.
+ * When this is sent off, there is no guarantee it is delivered, as the method
+ * returns immediately after queuing the message in the library.
+ *
+ * If you need guaranteed delivery, change your `acks` settings and use delivery reports.
  *
  * @param {string} topic - The topic name to produce to.
  * @param {number|null} partition - The partition number to produce to.
@@ -116,10 +123,9 @@ function Producer(conf, topicConf) {
  * @param {string} key - The key associated with the message.
  * @param {number|null} timestamp - Timestamp to send with the message.
  * @param {object} opaque - An object you want passed along with this message, if provided.
+ *                          This will be available in the delivery report
  * @param {object} headers - A list of custom key value pairs that provide message metadata.
- * @throws {LibrdKafkaError} - Throws a librdkafka error if it failed.
- * @return {boolean} - returns an error if it failed, or true if not
- * @see Producer#produce
+ * @return {boolean} - throws an error if it failed, or returns true if not.
  */
 Producer.prototype.produce = function(topic, partition, message, key, timestamp, opaque, headers) {
   if (!this._isConnected) {
@@ -146,11 +152,10 @@ Producer.prototype.produce = function(topic, partition, message, key, timestamp,
  *
  * This stream does not run in object mode. It only takes buffers of data.
  *
- * @param {object} conf - Key value pairs to configure the producer
- * @param {object} topicConf - Key value pairs to create a default
- * topic configuration
- * @param {object} streamOptions - Stream options
- * @return {ProducerStream} - returns the write stream for writing to Kafka.
+ * @param {object} conf - Key value pairs to configure the producer.
+ * @param {object} topicConf - Key value pairs to create a default topic configuration.
+ * @param {object} streamOptions - Stream options.
+ * @return {RdKafka.ProducerStream} - returns the write stream for writing to Kafka.
  */
 Producer.createWriteStream = function(conf, topicConf, streamOptions) {
   var producer = new Producer(conf, topicConf);
@@ -158,13 +163,14 @@ Producer.createWriteStream = function(conf, topicConf, streamOptions) {
 };
 
 /**
- * Poll for events
+ * Poll for events.
  *
  * We need to run poll in order to learn about new events that have occurred.
- * This is no longer done automatically when we produce, so we need to run
- * it manually, or set the producer to automatically poll.
+ * This is not done automatically when we produce, so we need to run
+ * it manually, or set the producer to automatically poll using
+ * {@link RdKafka.Producer#setPollInterval} or {@link RdKafka.Producer#setPollInBackground}.
  *
- * @return {Producer} - returns itself.
+ * @return {RdKafka.Producer} - returns itself.
  */
 Producer.prototype.poll = function() {
   if (!this._isConnected) {
@@ -179,11 +185,11 @@ Producer.prototype.poll = function() {
  *
  * We need to run poll in order to learn about new events that have occurred.
  * If you would like this done on an interval with disconnects and reconnections
- * managed, you can do it here
+ * managed, you can do it here.
  *
- * @param {number} interval - Interval, in milliseconds, to poll
+ * @param {number} interval - Interval, in milliseconds, to poll for.
  *
- * @return {Producer} - returns itself.
+ * @return {RdKafka.Producer} - returns itself.
  */
 Producer.prototype.setPollInterval = function(interval) {
   // If we already have a poll interval we need to stop it
@@ -237,26 +243,29 @@ Producer.prototype.setPollInterval = function(interval) {
  * does not happen on the event loop, but on the C thread spawned by librdkafka,
  * and can be more efficient for high-throughput producers.
  *
+ * If set = true, this will disable any polling interval set by `setPollInterval`.
+ *
  * @param {boolean} set Whether to poll in the background or not.
- * @note If set = true, this will disable any polling interval set by `setPollInterval`.
+ * @returns {RdKafka.Producer} - returns itself.
  */
 Producer.prototype.setPollInBackground = function(set) {
   if (set) {
     this.setPollInterval(0); // Clear poll interval from JS.
   }
   this._client.setPollInBackground(set);
+  return this;
 };
 
 /**
- * Flush the producer
+ * Flush the producer,
  *
- * Flush everything on the internal librdkafka producer buffer. Do this before
- * disconnects usually
+ * The producer accumulates messages upto `linger.ms` on an internal buffer.
+ * This method flushes on the buffer immediately. Do this before disconnects, usually.
  *
- * @param {number} timeout - Number of milliseconds to try to flush before giving up.
- * @param {function} callback - Callback to fire when the flush is done.
+ * @param {number?} timeout - Number of milliseconds to try to flush before giving up.
+ * @param {function?} callback - Callback to fire when the flush is done.
  *
- * @return {Producer} - returns itself.
+ * @return {RdKafka.Producer} - returns itself.
  */
 Producer.prototype.flush = function(timeout, callback) {
   if (!this._isConnected) {
@@ -280,17 +289,18 @@ Producer.prototype.flush = function(timeout, callback) {
 };
 
 /**
- * Save the base disconnect method here so we can overwrite it and add a flush
+ * Save the base disconnect method here so we can overwrite it and add a flush.
+ * @private
  */
 Producer.prototype._disconnect = Producer.prototype.disconnect;
 
 /**
- * Disconnect the producer
+ * Disconnect the producer.
  *
- * Flush everything on the internal librdkafka producer buffer. Then disconnect
+ * Flush everything on the internal librdkafka producer buffer. Then disconnect.
  *
- * @param {number} timeout - Number of milliseconds to try to flush before giving up, defaults to 5 seconds.
- * @param {function} cb - The callback to fire when
+ * @param {number?} timeout - Number of milliseconds to try to flush before giving up, defaults to 5 seconds.
+ * @param {function?} cb - The callback to fire when disconnected.
  */
 Producer.prototype.disconnect = function(timeout, cb) {
   var self = this;
@@ -308,13 +318,14 @@ Producer.prototype.disconnect = function(timeout, cb) {
 };
 
 /**
- * Init a transaction.
+ * Initialize transactions for this producer instance.
  *
- * Initialize transactions, this is only performed once per transactional producer.
+ * Initialize transactions, this must only be performed once per transactional producer,
+ * before it can be used.
  *
  * @param {number} timeout - Number of milliseconds to try to initialize before giving up, defaults to 5 seconds.
- * @param {function} cb - Callback to return when operation is completed
- * @return {Producer} - returns itself.
+ * @param {function} cb - Callback to fire when operation is completed.
+ * @return {RdKafka.Producer} - returns itself.
  */
 Producer.prototype.initTransactions = function(timeout, cb) {
   if (typeof timeout === 'function') {
@@ -329,9 +340,10 @@ Producer.prototype.initTransactions = function(timeout, cb) {
 /**
  * Begin a transaction.
  *
- * 'initTransaction' must have been called successfully (once) before this function is called.
+ * `initTransaction` must have been called successfully (once) before this function is called.
  *
- * @return {Producer} - returns itself.
+ * There can only be one ongoing transaction at a time.
+ * @return {RdKafka.Producer} - returns itself.
  */
 Producer.prototype.beginTransaction = function(cb) {
   this._client.beginTransaction(function(err) {
@@ -340,11 +352,11 @@ Producer.prototype.beginTransaction = function(cb) {
 };
 
 /**
- * Commit the current transaction (as started with 'beginTransaction').
+ * Commit the current transaction (as started with `beginTransaction`).
  *
- * @param {number} timeout - Number of milliseconds to try to commit before giving up, defaults to 5 seconds
- * @param {function} cb - Callback to return when operation is completed
- * @return {Producer} - returns itself.
+ * @param {number} timeout - Number of milliseconds to try to commit before giving up, defaults to 5 seconds.
+ * @param {function} cb - Callback to fire when operation is completed.
+ * @return {RdKafka.Producer} - returns itself.
  */
 Producer.prototype.commitTransaction = function(timeout, cb) {
   if (typeof timeout === 'function') {
@@ -357,11 +369,11 @@ Producer.prototype.commitTransaction = function(timeout, cb) {
 };
 
 /**
- * Aborts the ongoing transaction.
+ * Aborts the ongoing transaction (as started with `beginTransaction`).
  *
- * @param {number} timeout - Number of milliseconds to try to abort, defaults to 5 seconds
- * @param {function} cb - Callback to return when operation is completed
- * @return {Producer} - returns itself.
+ * @param {number} timeout - Number of milliseconds to try to abort, defaults to 5 seconds.
+ * @param {function} cb - Callback to fire when operation is completed.
+ * @return {RdKafka.Producer} - returns itself.
  */
 Producer.prototype.abortTransaction = function(timeout, cb) {
   if (typeof timeout === 'function') {
@@ -376,11 +388,11 @@ Producer.prototype.abortTransaction = function(timeout, cb) {
 /**
  * Send the current offsets of the consumer to the ongoing transaction.
  *
- * @param {number} offsets - Offsets to send as part of the next commit
- * @param {Consumer} consumer - An instance of the consumer
- * @param {number} timeout - Number of milliseconds to try to send offsets, defaults to 5 seconds
- * @param {function} cb - Callback to return when operation is completed
- * @return {Producer} - returns itself.
+ * @param {RdKafka.TopicPartition[]} offsets - An array of topic-partitions with offsets filled in.
+ * @param {RdKafka.KafkaConsumer} consumer - An instance of the consumer to send offsets for.
+ * @param {number} timeout - Number of milliseconds to try to send offsets, defaults to 5 seconds.
+ * @param {function} cb - Callback to return when operation is completed.
+ * @return {RdKafka.Producer} - returns itself.
  */
 Producer.prototype.sendOffsetsToTransaction = function(offsets, consumer, timeout, cb) {
   if (typeof timeout === 'function') {

--- a/lib/producer/high-level-producer.js
+++ b/lib/producer/high-level-producer.js
@@ -20,12 +20,14 @@ util.inherits(HighLevelProducer, Producer);
 var noopSerializer = createSerializer(function (v) { return v; });
 
 /**
- * Create a serializer
+ * Create a serializer.
  *
  * Method simply wraps a serializer provided by a user
- * so it adds context to the error
+ * so it adds context to the error.
  *
- * @returns {function} Serialization function
+ * @param {function} serializer - The serializer to wrap
+ * @returns {function} Serialization function.
+ * @private
  */
 function createSerializer(serializer) {
   var applyFn = function serializationWrapper(v, cb) {
@@ -49,12 +51,14 @@ function createSerializer(serializer) {
 }
 
 /**
- * Create a serializer that additionally takes the topic name
+ * Create a serializer that additionally takes the topic name.
  *
  * Method simply wraps a serializer provided by a user
- * so it adds context to the error
+ * so it adds context to the error.
  *
- * @returns {function} Serialization function
+ * @param {function} serializer - The serializer to wrap.
+ * @returns {function} Serialization function.
+ * @private
  */
 function createTopicSerializer(serializer) {
   var applyFn = function serializationWrapper(t, v, cb) {
@@ -78,33 +82,33 @@ function createTopicSerializer(serializer) {
 }
 
 /**
- * Producer class for sending messages to Kafka in a higher level fashion
+ * Producer class for sending messages to Kafka in a higher level fashion.
  *
  * This is the main entry point for writing data to Kafka if you want more
  * functionality than librdkafka supports out of the box. You
  * configure this like you do any other client, with a global
- * configuration and default topic configuration.
+ * configuration and an optional default topic configuration.
  *
  * Once you instantiate this object, you need to connect to it first.
  * This allows you to get the metadata and make sure the connection
  * can be made before you depend on it. After that, problems with
- * the connection will by brought down by using poll, which automatically
- * runs when a transaction is made on the object.
+ * the connection will be emitted when polling, which the HighLevelProducer
+ * does on its own.
  *
- * This has a few restrictions, so it is not for free!
+ * This has a few restrictions, so it is not for free.
  *
- * 1. You may not define opaque tokens
+ * 1. You may not define opaque tokens.
  *    The higher level producer is powered by opaque tokens.
  * 2. Every message ack will dispatch an event on the node thread.
  * 3. Will use a ref counter to determine if there are outgoing produces.
  *
  * This will return the new object you should use instead when doing your
- * produce calls
+ * produce calls.
  *
- * @param {object} conf - Key value pairs to configure the producer
- * @param {object} topicConf - Key value pairs to create a default
- * topic configuration
- * @extends Producer
+ * @param {object} conf - Key value pairs to configure the producer.
+ * @param {object?} topicConf - Key value pairs to create a default topic configuration.
+ * @extends RdKafka.Producer
+ * @memberof RdKafka
  * @constructor
  */
 function HighLevelProducer(conf, topicConf) {
@@ -174,7 +178,7 @@ function HighLevelProducer(conf, topicConf) {
  * This is the method mainly used in this class. Use it to produce
  * a message to Kafka.
  *
- * When this is sent off, and you recieve your callback, the assurances afforded
+ * When this is sent off, and you receive your callback, the assurances afforded
  * to you will be equal to those provided by your ack level.
  *
  * @param {string} topic - The topic name to produce to.
@@ -184,9 +188,10 @@ function HighLevelProducer(conf, topicConf) {
  * @param {number|null} timestamp - Timestamp to send with the message.
  * @param {object} headers - A list of custom key value pairs that provide message metadata.
  * @param {function} callback - Callback to call when the delivery report is recieved.
- * @throws {LibrdKafkaError} - Throws a librdkafka error if it failed.
- * @return {boolean} - returns an error if it failed, or true if not
- * @see Producer#produce
+ * @throws {RdKafka.LibrdKafkaError} - Throws a librdkafka error if it failed.
+ * @return {boolean} - Throws an error if it failed, or returns true if not.
+ * @see RdKafka.Producer#produce
+ * @alias RdKafka.HighLevelProducer#produce
  */
 HighLevelProducer.prototype._modifiedProduce = function(topic, partition, message, key, timestamp, headers, callback) {
   // headers are optional
@@ -349,40 +354,46 @@ HighLevelProducer.prototype._modifiedProduce = function(topic, partition, messag
 };
 
 /**
- * Set the key serializer
+ * Set the key serializer.
  *
- * This allows the value inside the produce call to differ from the value of the
- * value actually produced to kafka. Good if, for example, you want to serialize
+ * This allows the key inside the produce call to differ from the value of the
+ * key actually produced to kafka. Good if, for example, you want to serialize
  * it to a particular format.
+ *
+ * @param {function} serializer
  */
 HighLevelProducer.prototype.setKeySerializer = function(serializer) {
   this.keySerializer = createSerializer(serializer);
 };
 
 /**
- * Set the value serializer
+ * Set the value serializer.
  *
  * This allows the value inside the produce call to differ from the value of the
  * value actually produced to kafka. Good if, for example, you want to serialize
  * it to a particular format.
+ *
+ * @param {function} serializer
  */
 HighLevelProducer.prototype.setValueSerializer = function(serializer) {
   this.valueSerializer = createSerializer(serializer);
 };
 
 /**
- * Set the topic-key serializer
+ * Set the topic-key serializer.
  *
  * A serializer that takes the topic name in addition to the key.
+ * @param {function} serializer
  */
 HighLevelProducer.prototype.setTopicKeySerializer = function(serializer) {
   this.keySerializer = createTopicSerializer(serializer);
 };
 
 /**
- * Set the topic-value serializer
+ * Set the topic-value serializer.
  *
  * A serializer that takes the topic name in addition to the value.
+ * @param {function} serializer
  */
 HighLevelProducer.prototype.setTopicValueSerializer = function(serializer) {
   this.valueSerializer = createTopicSerializer(serializer);

--- a/lib/rdkafka.js
+++ b/lib/rdkafka.js
@@ -2,6 +2,7 @@
  * confluent-kafka-javascript - Node.js wrapper  for RdKafka C/C++ library
  *
  * Copyright (c) 2016-2023 Blizzard Entertainment
+ *           (c) 2024 Confluent, Inc.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
@@ -17,6 +18,10 @@ var Topic = require('./topic');
 var Admin = require('./admin');
 var features = lib.features().split(',');
 
+/**
+ * Namespace for non-promifisied, callback-based Kafka client API.
+ * @namespace RdKafka
+ */
 module.exports = {
   Consumer: util.deprecate(KafkaConsumer, 'Use KafkaConsumer instead. This may be changed in a later version'),
   Producer: Producer,

--- a/lib/tools/ref-counter.js
+++ b/lib/tools/ref-counter.js
@@ -17,6 +17,7 @@ module.exports = RefCounter;
  *
  * For the producer, it is used to begin rapid polling after a produce until
  * the delivery report is dispatched.
+ * @private
  */
 function RefCounter(onActive, onPassive) {
   this.context = {};

--- a/lib/topic-partition.js
+++ b/lib/topic-partition.js
@@ -16,6 +16,7 @@ module.exports = TopicPartition;
  *
  * @param array The array of topic partition raw objects to map to topic
  *              partition objects
+ * @private
  */
 TopicPartition.map = function(array) {
   return array.map(function(element) {
@@ -28,6 +29,7 @@ TopicPartition.map = function(array) {
  * The class will automatically convert offset identifiers to special constants
  *
  * @param element The topic partition raw javascript object
+ * @private
  */
 TopicPartition.create = function(element) {
   // Just ensure we take something that can have properties. The topic partition
@@ -42,6 +44,7 @@ TopicPartition.create = function(element) {
  *
  * Goal is still to behave like a plain javascript object but with validation
  * and potentially some extra methods
+ * @private
  */
 function TopicPartition(topic, partition, offset) {
   if (!(this instanceof TopicPartition)) {

--- a/lib/topic.js
+++ b/lib/topic.js
@@ -36,6 +36,7 @@ for (var key in librdkafka.topic) {
  * This is so that one day if there are interface changes that allow
  * different use of topic parameters, we can just add to this constructor and
  * have it return something richer
+ * @private
  */
 function Topic(topicName) {
   return topicName;

--- a/util/generate-docs.sh
+++ b/util/generate-docs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+tmp_log_file=$(mktemp)
+rm -rf docs
+
+# Generate documentation using jsdoc.
+# We can't rely on the output of the command since it doesn't support import() syntax for
+# types, and that is required for type hinting. So we'll just check if there are any errors
+# except for that later, by checking the file.
+./node_modules/jsdoc/jsdoc.js --destination docs --recurse -R ./README.md -c ./jsdoc.conf -a public,package,undefined 2>&1 | grep -v 'import(' > $tmp_log_file
+
+errors=$(wc -l $tmp_log_file | awk '{print $1}')
+
+if [ $errors -gt 0 ]; then
+  echo "Errors found in documentation generation"
+  cat $tmp_log_file
+  exit 1
+fi


### PR DESCRIPTION
This got way too big for my liking but jsdoc needed many, many things to work. There is no (reasonable) way to make the import() statement work so errors relating to that are just filtered out.

It's split into 3 commits

1. Makefile and config setup. 
2. Changes to code files to make jsdoc run without error. This is the biggest part but it should be okay because it's mostly just restructuring the comments. There are very minor code changes to facilitate some documentation (Object.freeze moved later, etc).
3. Add docs pipeline to semaphore so no future code changes break it.