### PR TITLE
eachBatch should respect partition restriction despite concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ v1.1.0 is a feature release. It is supported for all usage.
 
 1. Add support for an Admin API to fetch topic offsets by timestamp (#206).
 
+## Fixes
+
+1. Fixes an issue where the `eachBatch` callback was being called for the same partition concurrently (#224).
+
 
 # confluent-kafka-javascript v1.0.0
 

--- a/lib/kafkajs/_consumer_cache.js
+++ b/lib/kafkajs/_consumer_cache.js
@@ -241,11 +241,10 @@ class MessageCache {
 
         let nextN = ppc._nextN(size);
 
-        if (size === -1 || nextN.length < size) {
+        if (!nextN.length) {
             this.#removeEmptyPartition(ppc);
-        }
-        if (!nextN.length)
             return this.nextN(null, size);
+        }
 
         this.#size -= nextN.length;
         return [nextN, ppc];


### PR DESCRIPTION
Fixes #222 

Thanks @omer-riv for filing this issue and providing a reproducing case!

Details of the issue:
In the cache, next() "gives up" a partition when it tries to fetch something, and returns empty handed. The message returned to the user in this case is also null.

In the cache, nextN "gives up" partition assignment not only when it returns empty handed, but when we consume to the end of the partition (either leftover size = N or with -1 to consume everything). This is problematic because, we're returning a not-null set of messages to the user but not retaining partition ownership for that user. 

Solution: Make nextN like next.

Check the cache test for more details.