### PR TITLE
Update CHANGELOG.md to reflect non-release of kafka-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-# confluent-kafka-javascript v1.1.0
+# confluent-kafka-javascript v1.2.0
 
-v1.1.0 is a feature release. It is supported for all usage.
+v1.2.0 is a feature release. It is supported for all usage.
 
 ## Enhancements
 
 1. Add support for an Admin API to fetch topic offsets by timestamp (#206).
+
+
+# confluent-kafka-javascript v1.1.0
+
+v1.1.0 is a feature release. It is supported for all usage.
 
 ## Fixes
 


### PR DESCRIPTION
AdminAPI change isn't present in 1.1.0 as there's no kafka-client on 1.1.0, just an SR client. 