### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -52,4 +52,4 @@ util.dictToStringList = function (mapOrObject) {
   return list;
 };
 
-util.bindingVersion = '1.3.0-rc1';
+util.bindingVersion = '1.3.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@confluentinc/kafka-javascript",
-  "version": "1.3.0-rc1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@confluentinc/kafka-javascript",
-      "version": "1.3.0-rc1",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -11554,7 +11554,7 @@
     },
     "schemaregistry": {
       "name": "@confluentinc/schemaregistry",
-      "version": "1.3.0-rc1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.637.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confluentinc/kafka-javascript",
-  "version": "1.3.0-rc1",
+  "version": "1.3.0",
   "description": "Node.js bindings for librdkafka",
   "librdkafka": "2.10.0",
   "librdkafka_win": "2.10.0",

--- a/schemaregistry/package.json
+++ b/schemaregistry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confluentinc/schemaregistry",
-  "version": "1.3.0-rc1",
+  "version": "1.3.0",
   "description": "Node.js client for Confluent Schema Registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Successful post-install run for v1.3.0-rc1: https://semaphore.ci.confluent.io/workflows/8b1ab54c-4850-48ad-9506-65012569f1fb?pipeline_id=81a80cb7-bcd5-4cd7-89ac-5aa10271afd3
no changes after that