### PR TITLE
`[Typescript]` constructor config should be marked as optional

### DIFF
--- a/types/kafkajs.d.ts
+++ b/types/kafkajs.d.ts
@@ -94,7 +94,7 @@ export interface CommonConstructorConfig extends GlobalConfig {
 }
 
 export class Kafka {
-  constructor(config: CommonConstructorConfig)
+  constructor(config?: CommonConstructorConfig)
   producer(config?: ProducerConstructorConfig): Producer
   consumer(config: ConsumerConstructorConfig): Consumer
   admin(config?: AdminConstructorConfig): Admin


### PR DESCRIPTION


What
----
In most of example codes, `new Kafka()` is valid, but since the ts definition mark the config is mandatory, thus most of IDE will warn developer that config param is missing.

Checklist
------------------
- [x] Is customer facing change
- [x] No behavior changes
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - No, but if it is required, please let me know how 

References
----------


Test & Review
------------
Not yet

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

