### PR TITLE
Avoid a race condition that causes 100% usage of a CPU core 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# confluent-kafka-javascript v1.3.1
+
+v1.3.1 is a maintenance release. It is supported for all usage.
+
+## Fixes
+
+1. Avoid a race condition that causes 100% usage of a CPU core when 
+   consuming with `partitionsConsumedConcurrently > 1` and all messages
+   are consumed (#300)
+
+
 # confluent-kafka-javascript v1.3.0
 
 v1.3.0 is a feature release. It is supported for all usage.

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -24,7 +24,6 @@ const {
 const { Buffer } = require('buffer');
 const MessageCache = require('./_consumer_cache');
 const { hrtime } = require('process');
-const { LinkedList } = require('./_linked-list');
 
 const ConsumerState = Object.freeze({
   INIT: 0,
@@ -203,11 +202,10 @@ class Consumer {
    * It's set to null when no fetch is in progress.
    */
   #fetchInProgress;
-
   /**
-   * List of DeferredPromises waiting on consumer queue to be non-empty.
+   * Are we waiting for the queue to be non-empty?
    */
-  #queueWaiters = new LinkedList();
+  #nonEmpty = null;
 
   /**
    * Whether any rebalance callback is in progress.
@@ -363,7 +361,6 @@ class Consumer {
    */
   async #rebalanceCallback(err, assignment) {
     const isLost = this.#internalClient.assignmentLost();
-    this.#rebalanceCbInProgress = new DeferredPromise();
     let assignmentFnCalled = false;
     this.#logger.info(
       `Received rebalance event with message: '${err.message}' and ${assignment.length} partition(s), isLost: ${isLost}`,
@@ -468,7 +465,7 @@ class Consumer {
        */
       const workersToSpawn = Math.max(1, Math.min(this.#concurrency, this.#partitionCount));
       if (workersToSpawn !== this.#workers.length) {
-        this.#workerTerminationScheduled.resolve();
+        this.#resolveWorkerTerminationScheduled();
         /* We don't need to await the workers here. We are OK if the termination and respawning
           * occurs later, since even if we have a few more or few less workers for a while, it's
           * not a big deal. */
@@ -639,11 +636,14 @@ class Consumer {
     /* Certain properties that the user has set are overridden. We use trampolines to accommodate the user's callbacks.
      * TODO: add trampoline method for offset commit callback. */
     rdKafkaConfig['offset_commit_cb'] = true;
-    rdKafkaConfig['rebalance_cb'] = (err, assignment) => this.#rebalanceCallback(err, assignment).catch(e =>
+    rdKafkaConfig['rebalance_cb'] = (err, assignment) => {
+      this.#rebalanceCbInProgress = new DeferredPromise();
+      this.#rebalanceCallback(err, assignment).catch(e =>
       {
         if (this.#logger)
           this.#logger.error(`Error from rebalance callback: ${e.stack}`);
       });
+    };
 
     /* We handle offset storage within the promisified API by ourselves. Thus we don't allow the user to change this
      * setting and set it to false. */
@@ -904,6 +904,7 @@ class Consumer {
     const returnPayload = {
       batch,
       _stale: false,
+      _seeked: false,
       _lastResolvedOffset: { offset: -1, leaderEpoch: -1 },
       heartbeat: async () => { /* no op */ },
       pause: this.pause.bind(this, [{ topic, partitions: [partition] }]),
@@ -921,10 +922,11 @@ class Consumer {
   }
 
   async #fetchAndResolveWith(takeFromCache, size) {
-    if (this.#fetchInProgress) {
+    if (this.#fetchInProgress || this.#nonEmpty) {
       return null;
     }
 
+    let err, messages, processedRebalance = false;
     try {
       this.#fetchInProgress = new DeferredPromise();
       const fetchResult = new DeferredPromise();
@@ -933,8 +935,9 @@ class Consumer {
       this.#internalClient.consume(size, (err, messages) =>
         fetchResult.resolve([err, messages]));
 
-      let [err, messages] = await fetchResult;
+      [err, messages] = await fetchResult;
       if (this.#rebalanceCbInProgress) {
+        processedRebalance = true;
         await this.#rebalanceCbInProgress;
         this.#rebalanceCbInProgress = null;
       }
@@ -956,6 +959,8 @@ class Consumer {
     } finally {
       this.#fetchInProgress.resolve();
       this.#fetchInProgress = null;
+      if (!err && !processedRebalance && this.#messageCache.assignedSize === 0)
+        this.#nonEmpty = new DeferredPromise();
     }
   }
 
@@ -1316,7 +1321,7 @@ class Consumer {
 
     /* If any message is unprocessed, either due to an error or due to the user not marking it processed, we must seek
      * back to get it so it can be reprocessed. */
-    if (lastOffsetProcessed.offset !== lastOffset) {
+    if (!payload._seeked && lastOffsetProcessed.offset !== lastOffset) {
       const offsetToSeekTo = lastOffsetProcessed.offset === -1 ? firstMessage.offset : (lastOffsetProcessed.offset + 1);
       const leaderEpoch = lastOffsetProcessed.offset === -1 ? firstMessage.leaderEpoch : lastOffsetProcessed.leaderEpoch;
       this.seek({
@@ -1349,32 +1354,32 @@ class Consumer {
   }
 
   #queueNonEmptyCb() {
-    for (const waiter of this.#queueWaiters) {
-      waiter.resolve();
-    }
+    const nonEmptyAction = async () => {
+      if (this.#fetchInProgress)
+        await this.#fetchInProgress;
+
+      if (this.#nonEmpty) {
+        this.#nonEmpty.resolve();
+        this.#nonEmpty = null;
+      }
+      if (this.#messageCache)
+        this.#messageCache.notifyAvailablePartitions();
+    };
+    nonEmptyAction().catch((e) => {
+      this.#logger.error(`Error in queueNonEmptyCb: ${e}`,
+        this.#createConsumerBindingMessageMetadata());
+    });
   }
 
   async #nextFetchRetry() {
     if (this.#fetchInProgress) {
       await this.#fetchInProgress;
+    } else if (this.#nonEmpty) {
+      // In case there is any message in the queue we'll be woken up.
+      await this.#nonEmpty;
     } else {
-      /* Backoff a little. If m is null, we might be without messages
-       * or in available partition starvation, and calling consumeSingleCached
-       * in a tight loop will help no one.
-       * In case there is any message in the queue, we'll be woken up before the
-       * timer expires.
-       * We have a per-worker promise, otherwise we end up awakening
-       * other workers when they've already looped and just restarted awaiting.
-       * The `Promise` passed to `Timer.withTimeout` cannot be reused
-       * in next call to this method, to avoid memory leaks caused
-       * by `Promise.race`. */
-      const waiter = new DeferredPromise();
-      const waiterNode = this.#queueWaiters.addLast(waiter);
-      await Timer.withTimeout(1000, waiter);
-
-      /* Resolves the "extra" promise that has been spawned when creating the timer. */
-      waiter.resolve();
-      this.#queueWaiters.remove(waiterNode);
+      // In case there are new partitions to process, we'll be woken up.
+      await this.#messageCache.availablePartitions();
     }
   }
 
@@ -1395,25 +1400,26 @@ class Consumer {
     let ppc = null;
 
     while (!this.#workerTerminationScheduled.resolved) {
+      try {
+        const ms = await fetcher(ppc);
 
-      const ms = await fetcher(ppc).catch(e => {
+        if (this.#pendingOperations.length) {
+          ppc  = this.#discardMessages(ms, ppc);
+          break;
+        }
+
+        if (!ms) {
+          await this.#nextFetchRetry();
+          continue;
+        }
+
+        ppc = await perMessageProcessor(ms, config);
+      } catch (e) {
         /* Since this error cannot be exposed to the user in the current situation, just log and retry.
           * This is due to restartOnFailure being set to always true. */
         if (this.#logger)
           this.#logger.error(`Consumer encountered error while consuming. Retrying. Error details: ${e} : ${e.stack}`, this.#createConsumerBindingMessageMetadata());
-      });
-
-      if (this.#pendingOperations.length) {
-        ppc  = this.#discardMessages(ms, ppc);
-        break;
       }
-
-      if (!ms) {
-        await this.#nextFetchRetry();
-        continue;
-      }
-
-      ppc = await perMessageProcessor(ms, config);
     }
 
     if (ppc)
@@ -1479,6 +1485,13 @@ class Consumer {
       await op();
     }
     this.#pendingOperations = [];
+  }
+
+  #resolveWorkerTerminationScheduled() {
+    if (this.#workerTerminationScheduled) {
+      this.#workerTerminationScheduled.resolve();
+      this.#queueNonEmptyCb();
+    }
   }
 
   /**
@@ -1662,7 +1675,7 @@ class Consumer {
 
   #addPendingOperation(fun) {
     if (this.#pendingOperations.length === 0) {
-      this.#workerTerminationScheduled.resolve();
+      this.#resolveWorkerTerminationScheduled();
     }
     this.#pendingOperations.push(fun);
   }
@@ -1727,11 +1740,15 @@ class Consumer {
     }
   }
 
-  #markBatchPayloadsStale(topicPartitions) {
+  #markBatchPayloadsStale(topicPartitions, isSeek) {
     for (const topicPartition of topicPartitions) {
       const key = partitionKey(topicPartition);
-      if (this.#topicPartitionToBatchPayload.has(key))
-        this.#topicPartitionToBatchPayload.get(key)._stale = true;
+      if (this.#topicPartitionToBatchPayload.has(key)) {
+        const payload = this.#topicPartitionToBatchPayload.get(key);
+        payload._stale = true;
+        if (isSeek)
+          payload._seeked = true;
+      }
     }
   }
 
@@ -1757,7 +1774,7 @@ class Consumer {
       }
     }
     if (seekOffsets.length) {
-      await this.#seekInternal(seekOffsets, false);
+      await this.#seekInternal(seekOffsets);
     }
   }
 
@@ -1801,7 +1818,7 @@ class Consumer {
     }
 
     /* If anyone's using eachBatch, mark the batch as stale. */
-    this.#markBatchPayloadsStale([rdKafkaTopicPartitionOffset]);
+    this.#markBatchPayloadsStale([rdKafkaTopicPartitionOffset], true);
 
     this.#addPendingOperation(() =>
         this.#seekInternal([rdKafkaTopicPartitionOffset]));
@@ -2010,7 +2027,7 @@ class Consumer {
     }
 
     this.#disconnectStarted = true;
-    this.#workerTerminationScheduled.resolve();
+    this.#resolveWorkerTerminationScheduled();
     this.#logger.debug("Signalling disconnection attempt to workers", this.#createConsumerBindingMessageMetadata());
     await this.#lock.write(async () => {
 

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -922,7 +922,22 @@ class Consumer {
   }
 
   async #fetchAndResolveWith(takeFromCache, size) {
-    if (this.#fetchInProgress || this.#nonEmpty) {
+    if (this.#fetchInProgress) {
+      await this.#fetchInProgress;
+      /* Restart with the checks as we might have
+       * a new fetch in progress already. */
+      return null;
+    }
+
+    if (this.#nonEmpty) {
+      await this.#nonEmpty;
+      /* Restart with the checks as we might have
+       * a new fetch in progress already. */
+      return null;
+    }
+
+    if (this.#workerTerminationScheduled.resolved) {
+      /* Return without fetching. */
       return null;
     }
 
@@ -978,10 +993,13 @@ class Consumer {
     }
 
     /* It's possible that we get msg = null, but that's because partitionConcurrency
-     * exceeds the number of partitions containing messages. So in this case,
-     * we should not call for new fetches, rather, try to focus on what we have left.
+     * exceeds the number of partitions containing messages. So
+     * we should wait for a new partition to be available.
      */
     if (!msg && this.#messageCache.assignedSize !== 0) {
+      await this.#messageCache.availablePartitions();
+      /* Restart with the checks as we might have
+       * the cache full. */
       return null;
     }
 
@@ -1005,10 +1023,13 @@ class Consumer {
     }
 
     /* It's possible that we get msgs = null, but that's because partitionConcurrency
-     * exceeds the number of partitions containing messages. So in this case,
-     * we should not call for new fetches, rather, try to focus on what we have left.
+     * exceeds the number of partitions containing messages. So
+     * we should wait for a new partition to be available.
      */
     if (!msgs && this.#messageCache.assignedSize !== 0) {
+      await this.#messageCache.availablePartitions();
+      /* Restart with the checks as we might have
+       * the cache full. */
       return null;
     }
 
@@ -1370,19 +1391,6 @@ class Consumer {
         this.#createConsumerBindingMessageMetadata());
     });
   }
-
-  async #nextFetchRetry() {
-    if (this.#fetchInProgress) {
-      await this.#fetchInProgress;
-    } else if (this.#nonEmpty) {
-      // In case there is any message in the queue we'll be woken up.
-      await this.#nonEmpty;
-    } else {
-      // In case there are new partitions to process, we'll be woken up.
-      await this.#messageCache.availablePartitions();
-    }
-  }
-
   /**
    * Starts a worker to fetch messages/batches from the internal consumer and process them.
    *
@@ -1398,19 +1406,15 @@ class Consumer {
    */
   async #worker(config, perMessageProcessor, fetcher) {
     let ppc = null;
-
     while (!this.#workerTerminationScheduled.resolved) {
       try {
         const ms = await fetcher(ppc);
+        if (!ms)
+          continue;
 
         if (this.#pendingOperations.length) {
           ppc  = this.#discardMessages(ms, ppc);
           break;
-        }
-
-        if (!ms) {
-          await this.#nextFetchRetry();
-          continue;
         }
 
         ppc = await perMessageProcessor(ms, config);

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -1374,17 +1374,21 @@ class Consumer {
     return ppc;
   }
 
+  #notifyNonEmpty() {
+    if (this.#nonEmpty) {
+      this.#nonEmpty.resolve();
+      this.#nonEmpty = null;
+    }
+    if (this.#messageCache)
+      this.#messageCache.notifyAvailablePartitions();
+  }
+
   #queueNonEmptyCb() {
     const nonEmptyAction = async () => {
       if (this.#fetchInProgress)
         await this.#fetchInProgress;
 
-      if (this.#nonEmpty) {
-        this.#nonEmpty.resolve();
-        this.#nonEmpty = null;
-      }
-      if (this.#messageCache)
-        this.#messageCache.notifyAvailablePartitions();
+      this.#notifyNonEmpty();
     };
     nonEmptyAction().catch((e) => {
       this.#logger.error(`Error in queueNonEmptyCb: ${e}`,
@@ -1457,19 +1461,32 @@ class Consumer {
    * @private
    */
   async #cacheExpirationLoop() {
+    const cacheExpirationInterval = BigInt(this.#cacheExpirationTimeoutMs * 1e6);
+    const maxFetchInterval = BigInt(1000 * 1e6);
     while (!this.#workerTerminationScheduled.resolved) {
       let now = hrtime.bigint();
-      const cacheExpiration = this.#lastFetchClockNs +
-        BigInt(this.#cacheExpirationTimeoutMs * 1e6);
+      const cacheExpirationTimeout = this.#lastFetchClockNs +
+        cacheExpirationInterval;
+      const maxFetchTimeout = this.#lastFetchClockNs +
+        maxFetchInterval;
 
-      if (now > cacheExpiration) {
+      if (now > cacheExpirationTimeout) {
         this.#addPendingOperation(() =>
           this.#clearCacheAndResetPositions());
         await this.#checkMaxPollIntervalNotExceeded(now);
         break;
       }
+      if (now > maxFetchTimeout) {
+        /* We need to continue fetching even when we're
+         * not getting any messages, for example when all partitions are
+         * paused. */
+        this.#notifyNonEmpty();
+      }
 
-      let interval = Number(cacheExpiration - now) / 1e6;
+      const awakeTime = maxFetchTimeout < cacheExpirationTimeout ?
+        maxFetchTimeout : cacheExpirationTimeout;
+
+      let interval = Number(awakeTime - now) / 1e6;
       if (interval < 100)
         interval = 100;
       await Timer.withTimeout(interval, this.#maxPollIntervalRestart);

--- a/lib/kafkajs/_consumer_cache.js
+++ b/lib/kafkajs/_consumer_cache.js
@@ -278,7 +278,7 @@ class MessageCache {
      * Promise that resolved when there are available partitions to take.
      */
     async availablePartitions() {
-        await this.#availablePartitionsPromise;
+        return this.#availablePartitionsPromise;
     }
 }
 

--- a/lib/kafkajs/_consumer_cache.js
+++ b/lib/kafkajs/_consumer_cache.js
@@ -1,5 +1,6 @@
 const {
     partitionKey,
+    DeferredPromise,
 } = require('./_common');
 const { LinkedList } = require('./_linked-list');
 
@@ -74,6 +75,8 @@ class MessageCache {
     /* LinkedList of assigned partitions. */
     #assignedPartitions;
 
+    /* Promise that is resolved when there are available partitions. */
+    #availablePartitionsPromise = new DeferredPromise();
 
     constructor(logger) {
         this.logger = logger ?? console;
@@ -130,6 +133,7 @@ class MessageCache {
             cache = new PerPartitionMessageCache(key);
             this.#tpToPpc.set(key, cache);
             cache._node = this.#availablePartitions.addLast(cache);
+            this.notifyAvailablePartitions();
         }
         cache._add(message);
     }
@@ -197,6 +201,7 @@ class MessageCache {
             this.#assignedPartitions.remove(ppc._node);
             ppc._node = this.#availablePartitions.addLast(ppc);
             ppc._assigned = false;
+            this.notifyAvailablePartitions();
         }
     }
 
@@ -259,6 +264,21 @@ class MessageCache {
             ppc._assigned = false;
         }
         this.#reinit();
+    }
+
+    /**
+     * Notifies awaiters that there are available partitions to take.
+     */
+    notifyAvailablePartitions() {
+        this.#availablePartitionsPromise.resolve();
+        this.#availablePartitionsPromise = new DeferredPromise();
+    }
+
+    /**
+     * Promise that resolved when there are available partitions to take.
+     */
+    async availablePartitions() {
+        await this.#availablePartitionsPromise;
     }
 }
 

--- a/test/promisified/admin/list_topics.spec.js
+++ b/test/promisified/admin/list_topics.spec.js
@@ -4,7 +4,6 @@ const {
     secureRandom,
     createTopic,
     createAdmin,
-    sleep,
 } = require('../testhelpers');
 const { ErrorCodes } = require('../../../lib').KafkaJS;
 

--- a/test/promisified/admin/list_topics.spec.js
+++ b/test/promisified/admin/list_topics.spec.js
@@ -4,6 +4,7 @@ const {
     secureRandom,
     createTopic,
     createAdmin,
+    sleep,
 } = require('../testhelpers');
 const { ErrorCodes } = require('../../../lib').KafkaJS;
 
@@ -26,10 +27,20 @@ describe('Admin > listTopics', () => {
     it('should timeout', async () => {
         await admin.connect();
 
-        await expect(admin.listTopics({ timeout: 1 })).rejects.toHaveProperty(
-            'code',
-            ErrorCodes.ERR__TIMED_OUT
-        );
+        while (true) {
+            try {
+                await admin.listTopics({ timeout: 0.00001 });
+                jest.fail('Should have thrown an error');
+            } catch (e) {
+                if (e.code === ErrorCodes.ERR__TRANSPORT)
+                    continue;
+                expect(e).toHaveProperty(
+                    'code',
+                    ErrorCodes.ERR__TIMED_OUT
+                );
+                break;
+            }
+        }
     });
 
     it('should list consumer topics', async () => {

--- a/test/promisified/consumer/consumeMessages.spec.js
+++ b/test/promisified/consumer/consumeMessages.spec.js
@@ -412,19 +412,6 @@ describe.each(cases)('Consumer - partitionsConsumedConcurrently = %s -', (partit
             partitions: partitions,
         });
 
-        /* Reconfigure producer and consumer in such a way that batches are likely
-         * to be small and we get multiple partitions in the cache at once.
-         * This is to reduce flakiness. */
-        producer = createProducer({}, {
-            'batch.num.messages': 1,
-        });
-
-        consumer = createConsumer({
-            'groupId': groupId,
-        }, {
-            'fetch.message.max.bytes': 1,
-        });
-
         await producer.connect();
         await consumer.connect();
         await consumer.subscribe({ topic: topicName });
@@ -451,7 +438,7 @@ describe.each(cases)('Consumer - partitionsConsumedConcurrently = %s -', (partit
 
         await waitFor(() => consumer.assignment().length > 0, () => { }, 100);
 
-        const messages = Array(1024*9)
+        const messages = Array(4096 * 3)
             .fill()
             .map((_, i) => {
                 const value = secureRandom(512);

--- a/test/promisified/consumer/rebalanceCallback.spec.js
+++ b/test/promisified/consumer/rebalanceCallback.spec.js
@@ -18,6 +18,7 @@ describe('Consumer', () => {
         groupId = `consumer-group-id-${secureRandom()}`;
         consumerConfig = {
             groupId,
+            fromBeginning: true,
         };
         consumer = null;
         await createTopic({ topic: topicName, partitions: 3 });

--- a/test/promisified/consumer/seek.spec.js
+++ b/test/promisified/consumer/seek.spec.js
@@ -179,6 +179,8 @@ describe('Consumer seek >', () => {
                     topic: topicName,
                     messages: [message1, message2, message3, message4],
                 });
+                // Avoids a validation that resets the offset
+                // with subsequent seek
                 await producer.flush();
 
                 await consumer.subscribe({ topic: topicName });
@@ -306,7 +308,8 @@ describe('Consumer seek >', () => {
                 const message3 = { key: `key-0`, value: `value-${value3}`, partition: 0 };
 
                 await producer.send({ topic: topicName, messages: [message1, message2, message3] });
-                // Avoid an OUT OF RANGE when seeking
+                // Avoids a validation that resets the offset
+                // with subsequent seek
                 await producer.flush();
 
                 await consumer.subscribe({ topic: topicName, });

--- a/test/promisified/consumer/seek.spec.js
+++ b/test/promisified/consumer/seek.spec.js
@@ -422,8 +422,8 @@ describe('Consumer seek >', () => {
 
             consumer.run({
                 eachBatch: async ({ batch, isStale, resolveOffset }) => {
-                    if (offsetsConsumed.length == 0 && 
-                        batch.messages.length == 1) {
+                    if (offsetsConsumed.length === 0 && 
+                        batch.messages.length === 1) {
                         // Await a batch of at least two messages
                         resolveOffset(batch.messages[0].offset);
                         return;

--- a/test/promisified/consumer/seek.spec.js
+++ b/test/promisified/consumer/seek.spec.js
@@ -179,6 +179,7 @@ describe('Consumer seek >', () => {
                     topic: topicName,
                     messages: [message1, message2, message3, message4],
                 });
+                await producer.flush();
 
                 await consumer.subscribe({ topic: topicName });
 
@@ -305,6 +306,9 @@ describe('Consumer seek >', () => {
                 const message3 = { key: `key-0`, value: `value-${value3}`, partition: 0 };
 
                 await producer.send({ topic: topicName, messages: [message1, message2, message3] });
+                // Avoid an OUT OF RANGE when seeking
+                await producer.flush();
+
                 await consumer.subscribe({ topic: topicName, });
 
                 const messagesConsumed = [];
@@ -348,6 +352,11 @@ describe('Consumer seek >', () => {
     });
 
     describe('batch staleness >', () => {
+        beforeEach(async () => {
+            // Theses tests expect a single partititon
+            await createTopic({ topic: topicName, partitions: 1 });
+        });
+
         it('stops consuming messages after staleness', async () => {
             consumer = createConsumer({
                 groupId,
@@ -410,6 +419,13 @@ describe('Consumer seek >', () => {
 
             consumer.run({
                 eachBatch: async ({ batch, isStale, resolveOffset }) => {
+                    if (offsetsConsumed.length == 0 && 
+                        batch.messages.length == 1) {
+                        // Await a batch of at least two messages
+                        resolveOffset(batch.messages[0].offset);
+                        return;
+                    }
+
                     for (const message of batch.messages) {
                         if (isStale()) break;
 

--- a/test/promisified/consumer/seek.spec.js
+++ b/test/promisified/consumer/seek.spec.js
@@ -353,7 +353,7 @@ describe('Consumer seek >', () => {
 
     describe('batch staleness >', () => {
         beforeEach(async () => {
-            // Theses tests expect a single partititon
+            // These tests expect a single partititon
             await createTopic({ topic: topicName, partitions: 1 });
         });
 

--- a/test/promisified/producer/flush.spec.js
+++ b/test/promisified/producer/flush.spec.js
@@ -75,7 +75,7 @@ describe('Producer > Flush', () => {
             let messageSent = false;
 
             /* Larger number of messages */
-            producer.send({ topic: topicName, messages: Array(100).fill(message) }).then(() => {
+            producer.send({ topic: topicName, messages: Array(1000).fill(message) }).then(() => {
                 messageSent = true;
             });
 


### PR DESCRIPTION
when  consuming with `partitionsConsumedConcurrently > 1` and all messages are consumed.

Closes #195

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
When there are no messages available it's possible both workers alternate in fetching or waiting for `#fetchInProgress` and never reach the state where they await for `#queueNonEmptyCb`. Solved by having a different promise when a non-empty event is needed and avoiding resolving it when a fetch is in progress to avoid a double callback causes one of the two events to be lost.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
For reproducing before the fix or testing use the example code provided in #195

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
