### PR TITLE
feat: add support for Node v24

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -201,6 +201,7 @@ blocks:
                 - 21,120
                 - 22,127
                 - 23,131
+                - 24,136
           commands:
             - export NODE_VERSION=$(echo $NODE_VERSION_ABI | cut -d, -f1)
             - export NODE_ABI=$(echo $NODE_VERSION_ABI | cut -d, -f2)
@@ -237,6 +238,7 @@ blocks:
                 - 21,120
                 - 22,127
                 - 23,131
+                - 24,136
           commands:
             - export NODE_VERSION=$(echo $NODE_VERSION_ABI | cut -d, -f1)
             - export NODE_ABI=$(echo $NODE_VERSION_ABI | cut -d, -f2)
@@ -273,6 +275,7 @@ blocks:
                 - 21,120
                 - 22,127
                 - 23,131
+                - 24,136
           commands:
             - export NODE_VERSION=$(echo $NODE_VERSION_ABI | cut -d, -f1)
             - export NODE_ABI=$(echo $NODE_VERSION_ABI | cut -d, -f2)
@@ -309,6 +312,7 @@ blocks:
                 - 21,120
                 - 22,127
                 - 23,131
+                - 24,136
           commands:
             - export NODE_VERSION=$(echo $NODE_VERSION_ABI | cut -d, -f1)
             - export NODE_ABI=$(echo $NODE_VERSION_ABI | cut -d, -f2)
@@ -342,6 +346,7 @@ blocks:
                 - 21,120
                 - 22,127
                 - 23,131
+                - 24,136
           commands:
             - export NODE_VERSION=$(echo $NODE_VERSION_ABI | cut -d, -f1)
             - export NODE_ABI=$(echo $NODE_VERSION_ABI | cut -d, -f2)
@@ -377,6 +382,7 @@ blocks:
                 - 21,120
                 - 22,127
                 - 23,131
+                - 24,136
           commands:
             - export NODE_VERSION=$(echo $NODE_VERSION_ABI | cut -d, -f1)
             - export NODE_ABI=$(echo $NODE_VERSION_ABI | cut -d, -f2)
@@ -431,6 +437,7 @@ blocks:
                 - 21.6.1,120
                 - 22.2.0,127
                 - 23.2.0,131
+                - 24.0.0,136
           commands:
             - $env:NODE_VERSION = $env:NODE_VERSION_ABI.Split(',')[0]
             - $env:NODE_ABI = $env:NODE_VERSION_ABI.Split(',')[1]


### PR DESCRIPTION
What
----
Updated `semaphore.yml ` to add support for Node.js v24.  

Used the ABI version as listed in the JSON file located at:  https://github.com/nodejs/node/blob/main/doc/abi_version_registry.json

fixes  #306 

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
No testing done. Unclear how to run `semaphore.yml` file

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
