### PR TITLE
[KIP-848]: Structure change for DescribeConsumerGroups

### DIFF
--- a/examples/kafkajs/admin/describe-groups.js
+++ b/examples/kafkajs/admin/describe-groups.js
@@ -1,5 +1,5 @@
 // require('kafkajs') is replaced with require('@confluentinc/kafka-javascript').KafkaJS.
-const { Kafka, ConsumerGroupStates } = require('@confluentinc/kafka-javascript').KafkaJS;
+const { Kafka, ConsumerGroupStates, ConsumerGroupTypes } = require('@confluentinc/kafka-javascript').KafkaJS;
 const { parseArgs } = require('node:util');
 
 function printNode(node, prefix = '') {

--- a/examples/kafkajs/admin/describe-groups.js
+++ b/examples/kafkajs/admin/describe-groups.js
@@ -72,6 +72,7 @@ async function adminStart() {
       console.log(`\tProtocol type: ${group.protocolType}`);
       console.log(`\tPartition assignor: ${group.partitionAssignor}`);
       console.log(`\tState: ${group.state}`);
+      console.log(`\tType: ${group.type}`);
       console.log(`\tCoordinator: ${group.coordinator ? group.coordinator.id : group.coordinator}`);
       printNode(group.coordinator, '\t');
       console.log(`\tAuthorized operations: ${group.authorizedOperations}`);

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -29,6 +29,12 @@ const ConsumerGroupStates = {
   EMPTY: 5,
 };
 
+const ConsumerGroupTypes = {
+  UNKNOWN: 0,
+  CONSUMER: 1,
+  CLASSIC: 2,
+};
+
 /**
  * A list of ACL operation types.
  * @enum {number}
@@ -95,6 +101,7 @@ module.exports = {
   create: createAdminClient,
   createFrom: createAdminClientFrom,
   ConsumerGroupStates: Object.freeze(ConsumerGroupStates),
+  ConsumerGroupTypes: Object.freeze(ConsumerGroupTypes),
   AclOperationTypes: Object.freeze(AclOperationTypes),
   IsolationLevel: Object.freeze(IsolationLevel),
   OffsetSpec,

--- a/lib/kafkajs/_admin.js
+++ b/lib/kafkajs/_admin.js
@@ -1010,6 +1010,14 @@ module.exports = {
    */
   ConsumerGroupStates: RdKafka.AdminClient.ConsumerGroupStates,
   /**
+   * A list of consumer group types.
+   * @enum {number}
+   * @readonly
+   * @memberof KafkaJS
+   * @see RdKafka.ConsumerGroupTypes
+   */
+  ConsumerGroupTypes: RdKafka.AdminClient.ConsumerGroupTypes,
+  /**
    * A list of ACL operation types.
    * @enum {number}
    * @readonly

--- a/lib/kafkajs/_kafka.js
+++ b/lib/kafkajs/_kafka.js
@@ -1,6 +1,6 @@
 const { Producer, CompressionTypes } = require('./_producer');
 const { Consumer, PartitionAssigners } = require('./_consumer');
-const { Admin, ConsumerGroupStates, AclOperationTypes, IsolationLevel } = require('./_admin');
+const { Admin, ConsumerGroupStates, ConsumerGroupTypes, AclOperationTypes, IsolationLevel } = require('./_admin');
 const error = require('./_error');
 const { logLevel, checkIfKafkaJsKeysPresent, CompatibilityErrorMessages } = require('./_common');
 
@@ -119,6 +119,7 @@ module.exports = {
   PartitionAssigners,
   PartitionAssignors: PartitionAssigners,
   CompressionTypes,
+  ConsumerGroupTypes,
   ConsumerGroupStates,
   AclOperationTypes,
   IsolationLevel};

--- a/lib/rdkafka.js
+++ b/lib/rdkafka.js
@@ -39,5 +39,6 @@ module.exports = {
   IsolationLevel: Admin.IsolationLevel,
   OffsetSpec: Admin.OffsetSpec,
   ConsumerGroupStates: Admin.ConsumerGroupStates,
+  ConsumerGroupTypes: Admin.ConsumerGroupTypes,
   AclOperationTypes: Admin.AclOperationTypes,
 };

--- a/src/common.cc
+++ b/src/common.cc
@@ -1127,8 +1127,7 @@ v8::Local<v8::Object> FromConsumerGroupDescription(
 
   // type
   Nan::Set(returnObject, Nan::New("type").ToLocalChecked(),
-           Nan::New<v8::String>(rd_kafka_ConsumerGroupDescription_type(desc))
-               .ToLocalChecked());
+           Nan::New<v8::Number>(rd_kafka_ConsumerGroupDescription_type(desc)));
 
   // coordinator
   const rd_kafka_Node_t* coordinator =

--- a/src/common.cc
+++ b/src/common.cc
@@ -980,6 +980,9 @@ v8::Local<v8::Object> FromMemberDescription(
         assignment: {
           topicPartitions: TopicPartition[]
         },
+        targetAssignment?: {
+          topicPartitions: TopicPartition[]
+        }
     }
   */
   v8::Local<v8::Object> returnObject = Nan::New<v8::Object>();
@@ -1027,6 +1030,23 @@ v8::Local<v8::Object> FromMemberDescription(
            topicPartitions);
   Nan::Set(returnObject, Nan::New("assignment").ToLocalChecked(),
            assignmentObject);
+
+  // targetAssignment
+  const rd_kafka_MemberAssignment_t* target_assignment =
+      rd_kafka_MemberDescription_target_assignment(member);
+  if (target_assignment) {
+    const rd_kafka_topic_partition_list_t* target_partitions =
+        rd_kafka_MemberAssignment_partitions(target_assignment);
+    v8::Local<v8::Array> targetTopicPartitions =
+        Conversion::TopicPartition::ToTopicPartitionV8Array(
+            target_partitions, false);
+    v8::Local<v8::Object> targetAssignmentObject = Nan::New<v8::Object>();
+    Nan::Set(targetAssignmentObject,
+             Nan::New("topicPartitions").ToLocalChecked(),
+             targetTopicPartitions);
+    Nan::Set(returnObject, Nan::New("targetAssignment").ToLocalChecked(),
+             targetAssignmentObject);
+  }
 
   return returnObject;
 }
@@ -1104,6 +1124,11 @@ v8::Local<v8::Object> FromConsumerGroupDescription(
   // state
   Nan::Set(returnObject, Nan::New("state").ToLocalChecked(),
            Nan::New<v8::Number>(rd_kafka_ConsumerGroupDescription_state(desc)));
+
+  // type
+  Nan::Set(returnObject, Nan::New("type").ToLocalChecked(),
+           Nan::New<v8::String>(rd_kafka_ConsumerGroupDescription_type(desc))
+               .ToLocalChecked());
 
   // coordinator
   const rd_kafka_Node_t* coordinator =

--- a/test/promisified/admin/describe_groups.spec.js
+++ b/test/promisified/admin/describe_groups.spec.js
@@ -67,9 +67,6 @@ describe('Admin > describeGroups', () => {
     });
 
     it('should describe consumer groups', async () => {
-        if (testConsumerGroupProtocolClassic()) {
-            return ;
-        }
         let messagesConsumed = 0;
 
         await consumer.connect();
@@ -90,7 +87,7 @@ describe('Admin > describeGroups', () => {
                 isSimpleConsumerGroup: false,
                 protocolType: 'consumer',
                 state: ConsumerGroupStates.STABLE,
-                type: ConsumerGroupTypes.CLASSIC,
+                type: testConsumerGroupProtocolClassic() ? ConsumerGroupTypes.CLASSIC : ConsumerGroupTypes.CONSUMER,
                 coordinator: expect.objectContaining({
                     id: expect.any(Number),
                     host: expect.any(String),
@@ -142,7 +139,7 @@ describe('Admin > describeGroups', () => {
                 protocol: expect.any(String),
                 partitionAssignor: expect.any(String),
                 state: ConsumerGroupStates.EMPTY,
-                type: ConsumerGroupTypes.CLASSIC,
+                type: testConsumerGroupProtocolClassic() ? ConsumerGroupTypes.CLASSIC : ConsumerGroupTypes.CONSUMER,
                 protocolType: 'consumer',
                 isSimpleConsumerGroup: false,
                 coordinator: expect.objectContaining({

--- a/test/promisified/admin/describe_groups.spec.js
+++ b/test/promisified/admin/describe_groups.spec.js
@@ -10,7 +10,7 @@ const {
     createAdmin,
     sleep,
 } = require('../testhelpers');
-const { ConsumerGroupStates, ErrorCodes, AclOperationTypes } = require('../../../lib').KafkaJS;
+const { ConsumerGroupStates, ConsumerGroupTypes, ErrorCodes, AclOperationTypes } = require('../../../lib').KafkaJS;
 
 describe('Admin > describeGroups', () => {
     let topicName, groupId, consumer, admin, groupInstanceId, producer;
@@ -90,6 +90,7 @@ describe('Admin > describeGroups', () => {
                 isSimpleConsumerGroup: false,
                 protocolType: 'consumer',
                 state: ConsumerGroupStates.STABLE,
+                type: ConsumerGroupTypes.CLASSIC,
                 coordinator: expect.objectContaining({
                     id: expect.any(Number),
                     host: expect.any(String),
@@ -141,6 +142,7 @@ describe('Admin > describeGroups', () => {
                 protocol: expect.any(String),
                 partitionAssignor: expect.any(String),
                 state: ConsumerGroupStates.EMPTY,
+                type: ConsumerGroupTypes.CLASSIC,
                 protocolType: 'consumer',
                 isSimpleConsumerGroup: false,
                 coordinator: expect.objectContaining({

--- a/types/rdkafka.d.ts
+++ b/types/rdkafka.d.ts
@@ -352,6 +352,12 @@ export enum ConsumerGroupStates {
     EMPTY = 5,
 }
 
+export enum ConsumerGroupTypes {
+    UNKNOWN = 0,
+    CONSUMER = 1,
+    CLASSIC = 2,
+}
+
 export interface GroupOverview {
     groupId: string;
     protocolType: string;
@@ -383,6 +389,7 @@ export type MemberDescription = {
     memberMetadata: Buffer
     groupInstanceId?: string,
     assignment: TopicPartition[]
+    targetAssignment?: TopicPartition[]
 }
 
 export type Node = {
@@ -407,6 +414,7 @@ export type GroupDescription = {
     protocolType: string
     partitionAssignor: string
     state: ConsumerGroupStates
+    type: ConsumerGroupTypes
     coordinator: Node
     authorizedOperations?: AclOperationTypes[]
 }


### PR DESCRIPTION
This PR intends to add two new field type and target assignment for DescribeConsumerGroup Response.