### PR TITLE
fix: Apply timeout correctly to consumeNum

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -564,8 +564,8 @@ describe('Consumer/Producer', function() {
           setTimeout(producer.produce(topic, null, buffer, null), 500 * i);
         }
 
-        // Batch size large enough to not interfere with timeout test
         const start = Date.now();
+        // Batch size large enough to not interfere with timeout test
         consumer.consume(100, function(err, messages) {
           t.ifError(err);
           t.equal(messages.length, messageCount, 'Consume should wait for all messages because of debounce');
@@ -592,6 +592,7 @@ describe('Consumer/Producer', function() {
           setTimeout(producer.produce(topic, null, buffer, null), 500 * i);
         }
 
+        const start = Date.now();
         // Batch size large enough to not interfere with timeout test
         consumer.consume(100, function(err, messages) {
           t.ifError(err);

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -576,7 +576,7 @@ describe('Consumer/Producer', function() {
     })
 
     it('should return after timeout when bool is true', function(done) {
-      crypto.randomBytes(4096, function (_ex, buffer) {
+      crypto.randomBytes(4096, function(_ex, buffer) {
         consumer.setDefaultIsTimeoutSharedByBatch(true);
         consumer.setDefaultConsumeTimeout(1000);
 
@@ -601,7 +601,6 @@ describe('Consumer/Producer', function() {
           done();
         })
       })
-
     })
   })
 

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -353,7 +353,6 @@ describe('Consumer/Producer', function() {
     });
   });
 
-
   it('should be able to produce and consume messages: consumeLoop', function(done) {
     var key = 'key';
 

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -561,7 +561,7 @@ describe('Consumer/Producer', function() {
 
         let messageCount = 5;
         for (let i = 0; i < messageCount; i++) {
-          setTimeout(producer.produce(topic, null, buffer, null), 500 * i);
+          setTimeout(() => producer.produce(topic, null, buffer, null), 500 * i);
         }
 
         const start = Date.now();
@@ -589,7 +589,7 @@ describe('Consumer/Producer', function() {
 
         let messageCount = 5;
         for (let i = 0; i < messageCount; i++) {
-          setTimeout(producer.produce(topic, null, buffer, null), 500 * i);
+          setTimeout(() => producer.produce(topic, null, buffer, null), 500 * i);
         }
 
         const start = Date.now();

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -547,7 +547,7 @@ describe('Consumer/Producer', function() {
   });
 
   describe('Timeout Shared By Batch - Behavior', function() {
-    it('should debounce batch return when is false', function(done) {
+    it('should debounce batch return when bool is false', function(done) {
       crypto.randomBytes(4096, function(_ex, buffer) {
         consumer.setDefaultIsTimeoutSharedByBatch(false);
         consumer.setDefaultConsumeTimeout(1000);

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -310,11 +310,10 @@ describe('Consumer/Producer', function() {
 
         let messageCount = 12;
         for (let i = 0; i < messageCount; i++) {
-          setTimeout(() => producer.produce(topic, null, buffer, null), 500 * i);
+          setTimeout(() => producer.produce(topic, null, buffer, null), 500 * i); // messages come in staggered under timeout
         }
 
         const start = Date.now();
-        // Batch size large enough to not interfere with timeout test
         consumer.consume(1000, function(err, messages) {
           t.ifError(err);
           t.equal(messages.length, messageCount, 'Consume should wait for all messages because of debounce');
@@ -338,11 +337,10 @@ describe('Consumer/Producer', function() {
 
         let messageCount = 12;
         for (let i = 0; i < messageCount; i++) {
-          setTimeout(() => producer.produce(topic, null, buffer, null), 500 * i);
+          setTimeout(() => producer.produce(topic, null, buffer, null), 500 * i); // messages come in staggered under timeout
         }
 
         const start = Date.now();
-        // Batch size large enough to not interfere with timeout test
         consumer.consume(1000, function(err, messages) {
           t.ifError(err);
           t.notEqual(messages.length, messageCount, 'Consume should fail to get all messages because of timeout');

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -21,6 +21,7 @@ var shallowCopy = require('./util').shallowCopy;
 var DEFAULT_CONSUME_LOOP_TIMEOUT_DELAY = 500;
 var DEFAULT_CONSUME_TIME_OUT = 1000;
 const DEFAULT_IS_TIMEOUT_ONLY_FOR_FIRST_MESSAGE = false;
+const DEFAULT_IS_TIMEOUT_SHARED_BY_BATCH = false;
 util.inherits(KafkaConsumer, Client);
 
 /**
@@ -136,6 +137,7 @@ function KafkaConsumer(conf, topicConf) {
   this._consumeTimeout = DEFAULT_CONSUME_TIME_OUT;
   this._consumeLoopTimeoutDelay = DEFAULT_CONSUME_LOOP_TIMEOUT_DELAY;
   this._consumeIsTimeoutOnlyForFirstMessage = DEFAULT_IS_TIMEOUT_ONLY_FOR_FIRST_MESSAGE;
+  this._consumeIsTimeoutSharedByBatch = DEFAULT_IS_TIMEOUT_SHARED_BY_BATCH;
 
   if (queue_non_empty_cb) {
     this._cb_configs.event.queue_non_empty_cb = queue_non_empty_cb;
@@ -173,6 +175,21 @@ KafkaConsumer.prototype.setDefaultConsumeLoopTimeoutDelay = function(intervalMs)
  */
 KafkaConsumer.prototype.setDefaultIsTimeoutOnlyForFirstMessage = function(isTimeoutOnlyForFirstMessage) {
   this._consumeIsTimeoutOnlyForFirstMessage = isTimeoutOnlyForFirstMessage;
+};
+
+/**
+ * If true:
+ *  In consume(number, cb), consume will attempt to fill the batch size until `timeoutMs` passes.
+ *
+ * If false:
+ *  In consume(number, cb), we will wait for upto `timeoutMs` after the most recent message is ready.
+ *  i.e. As long as messages are continuously arriving, consume will not return until the batch size is full.
+ *
+ * @param {boolean} isTimeoutSharedByBatch
+ * @private
+ */
+KafkaConsumer.prototype.setDefaultIsTimeoutSharedByBatch = function (isTimeoutSharedByBatch) {
+  this._consumeIsTimeoutSharedByBatch = isTimeoutSharedByBatch;
 };
 
 /**
@@ -552,7 +569,7 @@ KafkaConsumer.prototype._consumeLoop = function(timeoutMs, cb) {
 KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
   var self = this;
 
-  this._client.consume(timeoutMs, numMessages, this._consumeIsTimeoutOnlyForFirstMessage, function(err, messages, eofEvents) {
+  this._client.consume(timeoutMs, numMessages, this._consumeIsTimeoutOnlyForFirstMessage, this._consumeIsTimeoutSharedByBatch, function(err, messages, eofEvents) {
     if (err) {
       err = LibrdKafkaError.create(err);
       if (cb) {

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -807,8 +807,8 @@ KafkaConsumerConsumeNum::KafkaConsumerConsumeNum(Nan::Callback *callback,
   m_consumer(consumer),
   m_num_messages(num_messages),
   m_timeout_ms(timeout_ms),
-  m_timeout_only_for_first_message(timeout_only_for_first_message,
-  m_timeout_shared_by_batch) {}
+  m_timeout_only_for_first_message(timeout_only_for_first_message),
+  m_timeout_shared_by_batch(timeout_shared_by_batch) {}
 
 KafkaConsumerConsumeNum::~KafkaConsumerConsumeNum() {}
 

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -9,6 +9,7 @@
  */
 #include "src/workers.h"
 
+#include <algorithm>
 #include <chrono>
 #include <string>
 #include <vector>
@@ -825,7 +826,7 @@ void KafkaConsumerConsumeNum::Execute() {
   }
 
   while (m_messages.size() - eof_event_count < max && looping) {
-    // Allow timeout_ms = early_exit_ms to take precedence 
+    // Allow timeout_ms = early_exit_ms to take precedence
     // timeout_ms > 1
     if (m_timeout_shared_by_batch && timeout_ms > early_exit_ms) {
       // Calc next single consume timeout remaining for batch

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -825,8 +825,9 @@ void KafkaConsumerConsumeNum::Execute() {
       auto elapsed =
         std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time)
         .count();
-      // timeout_ms of 0 triggers non-blocking behavior https://github.com/confluentinc/librdkafka/blob/3f52de491f8aae1d71a9a0b3f1c07bfd6df4aec3/src/rdkafka_int.h#L1189-L1190
-      timeout_ms = std::max(1, m_timeout_ms - static_cast<int>(elapsed));
+      // `timeout_ms` of 0 triggers non-blocking behavior https://github.com/confluentinc/librdkafka/blob/3f52de491f8aae1d71a9a0b3f1c07bfd6df4aec3/src/rdkafka_int.h#L1189-L1190
+      // This still returns ERR_TIMED_OUT if no message available
+      timeout_ms = std::max(0, m_timeout_ms - static_cast<int>(elapsed));
     }
 
     // Get a message

--- a/src/workers.h
+++ b/src/workers.h
@@ -457,7 +457,7 @@ class KafkaConsumerSeek : public ErrorAwareWorker {
 class KafkaConsumerConsumeNum : public ErrorAwareWorker {
  public:
   KafkaConsumerConsumeNum(Nan::Callback*, NodeKafka::KafkaConsumer*,
-    const uint32_t &, const int &, bool);
+    const uint32_t &, const int &, bool, bool);
   ~KafkaConsumerConsumeNum();
 
   void Execute();
@@ -468,6 +468,7 @@ class KafkaConsumerConsumeNum : public ErrorAwareWorker {
   const uint32_t m_num_messages;
   const int m_timeout_ms;
   const bool m_timeout_only_for_first_message;
+  const bool m_timeout_shared_by_batch;
   std::vector<RdKafka::Message*> m_messages;
 };
 


### PR DESCRIPTION
What
----
Applies timeout to the entire batch instead of on a per message basis.

How
----
The calls to the individual consume share the batch timeout and each call to consume can only use the timeout that the batch has remaining.

Why
----
The existing behavior is described in detail in [this issue](https://github.com/confluentinc/confluent-kafka-javascript/issues/262).

In short, for `d` millisecond delay, `c` count, and `b` blocking time: `b = d * c`, given a constant topic rpm  `60000 / d`.

Given any rpm `> 60000 / d`: `b = c * (60 / rpm)` seconds

For example, a 1000ms delay with a batch count of 100 will cause the `consumeNum` loop to block for up to 100 seconds given a constant topic rpm of 60. 


References
----------
Issue: https://github.com/confluentinc/confluent-kafka-javascript/issues/262
PR Introduced: https://github.com/Blizzard/node-rdkafka/pull/34

PRs in node-rdkafka addressing the same issue:
https://github.com/Blizzard/node-rdkafka/pull/1061
https://github.com/Blizzard/node-rdkafka/pull/1053

Test & Review
------------
With c = 100, d = 1000, rpm = 700, expectation is that pre-change we'd block for about 8.6 seconds (it seems like it takes longer in the example, though) before returning the 100 messages.

My testing environment has a 50ms cooldown on calling `consume`, so after the change we expect a batch of messages to be returned every 1050ms. 

Pre-Change
![confluent-node-rdkafka-pre2](https://github.com/user-attachments/assets/9f20f506-53f7-42f8-b673-b8c70ef8ef9b)

Post-Change
![confluent-node-rdkafka-post2](https://github.com/user-attachments/assets/20e348af-4dc9-4430-90f3-570bb1de0efb)
