### PR TITLE
Update to TypeScript 5.9; Uint8Array to Uint8Array<ArrayBuffer>

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@confluentinc/kafka-javascript": "file:../..",
-    "typescript": "^5.4.4"
+    "typescript": "^5.9.2"
   },
   "devDependencies": {
     "@types/node": "^20.12.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "node-gyp": "^9.3.1",
         "nyc": "^17.1.0",
         "ts-jest": "^29.2.5",
-        "typescript": "^5.5.4",
+        "typescript": "^5.9.2",
         "typescript-eslint": "^8.2.0"
       },
       "engines": {
@@ -11936,7 +11936,7 @@
         "mocha": "^10.7.0",
         "node-gyp": "^9.3.1",
         "ts-jest": "^29.2.4",
-        "typescript": "^5.5.4",
+        "typescript": "^5.9.2",
         "typescript-eslint": "^8.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "node-gyp": "^9.3.1",
     "nyc": "^17.1.0",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.5.4",
+    "typescript": "^5.9.2",
     "typescript-eslint": "^8.2.0"
   },
   "dependencies": {

--- a/schemaregistry/package.json
+++ b/schemaregistry/package.json
@@ -25,7 +25,7 @@
     "mocha": "^10.7.0",
     "node-gyp": "^9.3.1",
     "ts-jest": "^29.2.4",
-    "typescript": "^5.5.4",
+    "typescript": "^5.9.2",
     "typescript-eslint": "^8.2.0"
   },
   "dependencies": {

--- a/schemaregistry/rules/encryption/encrypt-executor.ts
+++ b/schemaregistry/rules/encryption/encrypt-executor.ts
@@ -170,7 +170,7 @@ export class EncryptionExecutor implements RuleExecutor {
 }
 
 export class Cryptor {
-  static readonly EMPTY_AAD = Buffer.from([])
+  static readonly EMPTY_AAD: Uint8Array<ArrayBuffer> = new Uint8Array(0)
 
   dekFormat: DekFormat
   isDeterministic: boolean
@@ -222,13 +222,13 @@ export class Cryptor {
     switch (this.dekFormat) {
       case DekFormat.AES256_SIV:
         const aesSivKey = fromBinary(AesSivKeySchema, dek)
-        rawKey = aesSivKey.keyValue
-        return Buffer.from(await this.encryptWithAesSiv(rawKey, plaintext))
+        rawKey = new Uint8Array(aesSivKey.keyValue)
+        return Buffer.from(await this.encryptWithAesSiv(rawKey as Uint8Array<ArrayBuffer>, new Uint8Array(plaintext)))
       case DekFormat.AES128_GCM:
       case DekFormat.AES256_GCM:
         const aesGcmKey = fromBinary(AesGcmKeySchema, dek)
-        rawKey = aesGcmKey.keyValue
-        return Buffer.from(await this.encryptWithAesGcm(rawKey, plaintext))
+        rawKey = new Uint8Array(aesGcmKey.keyValue)
+        return Buffer.from(await this.encryptWithAesGcm(rawKey as Uint8Array<ArrayBuffer>, new Uint8Array(plaintext)))
       default:
         throw new RuleError('unsupported dek format')
     }
@@ -239,34 +239,34 @@ export class Cryptor {
     switch (this.dekFormat) {
       case DekFormat.AES256_SIV:
         const aesSivKey = fromBinary(AesSivKeySchema, dek)
-        rawKey = aesSivKey.keyValue
-        return Buffer.from(await this.decryptWithAesSiv(rawKey, ciphertext))
+        rawKey = new Uint8Array(aesSivKey.keyValue)
+        return Buffer.from(await this.decryptWithAesSiv(rawKey as Uint8Array<ArrayBuffer>, new Uint8Array(ciphertext)))
       case DekFormat.AES128_GCM:
       case DekFormat.AES256_GCM:
         const aesGcmKey = fromBinary(AesGcmKeySchema, dek)
-        rawKey = aesGcmKey.keyValue
-        return Buffer.from(await this.decryptWithAesGcm(rawKey, ciphertext))
+        rawKey = new Uint8Array(aesGcmKey.keyValue)
+        return Buffer.from(await this.decryptWithAesGcm(rawKey as Uint8Array<ArrayBuffer>, new Uint8Array(ciphertext)))
       default:
         throw new RuleError('unsupported dek format')
     }
   }
 
-  async encryptWithAesSiv(key: Uint8Array, plaintext: Uint8Array): Promise<Uint8Array> {
+  async encryptWithAesSiv(key: Uint8Array<ArrayBuffer>, plaintext: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
     const aead = await aesSivFromRawKey(key)
     return aead.encrypt(plaintext, Cryptor.EMPTY_AAD)
   }
 
-  async decryptWithAesSiv(key: Uint8Array, ciphertext: Uint8Array): Promise<Uint8Array> {
+  async decryptWithAesSiv(key: Uint8Array<ArrayBuffer>, ciphertext: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
     const aead = await aesSivFromRawKey(key)
     return aead.decrypt(ciphertext, Cryptor.EMPTY_AAD)
   }
 
-  async encryptWithAesGcm(key: Uint8Array, plaintext: Uint8Array): Promise<Uint8Array> {
+  async encryptWithAesGcm(key: Uint8Array<ArrayBuffer>, plaintext: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
     const aead = await aesGcmFromRawKey(key)
     return aead.encrypt(plaintext, Cryptor.EMPTY_AAD)
   }
 
-  async decryptWithAesGcm(key: Uint8Array, ciphertext: Uint8Array): Promise<Uint8Array> {
+  async decryptWithAesGcm(key: Uint8Array<ArrayBuffer>, ciphertext: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
     const aead = await aesGcmFromRawKey(key)
     return aead.decrypt(ciphertext, Cryptor.EMPTY_AAD)
   }

--- a/schemaregistry/rules/encryption/tink/aead.ts
+++ b/schemaregistry/rules/encryption/tink/aead.ts
@@ -29,8 +29,8 @@ export abstract class Aead {
    * @returns resulting ciphertext
    *
    */
-  abstract encrypt(plaintext: Uint8Array, opt_associatedData?: Uint8Array|null):
-      Promise<Uint8Array>;
+  abstract encrypt(plaintext: Uint8Array<ArrayBuffer>, opt_associatedData?: Uint8Array<ArrayBuffer>|null):
+      Promise<Uint8Array<ArrayBuffer>>;
 
   /**
    * Decrypts ciphertext with associated authenticated data.
@@ -46,6 +46,6 @@ export abstract class Aead {
    * @returns resulting plaintext
    */
   abstract decrypt(
-      ciphertext: Uint8Array,
-      opt_associatedData?: Uint8Array|null): Promise<Uint8Array>;
+      ciphertext: Uint8Array<ArrayBuffer>,
+      opt_associatedData?: Uint8Array<ArrayBuffer>|null): Promise<Uint8Array<ArrayBuffer>>;
 }

--- a/schemaregistry/rules/encryption/tink/aes_gcm.ts
+++ b/schemaregistry/rules/encryption/tink/aes_gcm.ts
@@ -34,8 +34,8 @@ export class AesGcm extends Aead {
 
   /**
    */
-  async encrypt(plaintext: Uint8Array, associatedData?: Uint8Array):
-      Promise<Uint8Array> {
+  async encrypt(plaintext: Uint8Array<ArrayBuffer>, associatedData?: Uint8Array<ArrayBuffer>):
+      Promise<Uint8Array<ArrayBuffer>> {
     Validators.requireUint8Array(plaintext);
     if (associatedData != null) {
       Validators.requireUint8Array(associatedData);
@@ -56,8 +56,8 @@ export class AesGcm extends Aead {
 
   /**
    */
-  async decrypt(ciphertext: Uint8Array, associatedData?: Uint8Array):
-      Promise<Uint8Array> {
+  async decrypt(ciphertext: Uint8Array<ArrayBuffer>, associatedData?: Uint8Array<ArrayBuffer>):
+      Promise<Uint8Array<ArrayBuffer>> {
     Validators.requireUint8Array(ciphertext);
     if (ciphertext.length < IV_SIZE_IN_BYTES + TAG_SIZE_IN_BITS / 8) {
       throw new SecurityException('ciphertext too short');
@@ -88,7 +88,7 @@ export class AesGcm extends Aead {
   }
 }
 
-export async function fromRawKey(key: Uint8Array): Promise<Aead> {
+export async function fromRawKey(key: Uint8Array<ArrayBuffer>): Promise<Aead> {
   Validators.requireUint8Array(key);
   Validators.validateAesKeySize(key.length);
   const webCryptoKey = await crypto.subtle.importKey(

--- a/schemaregistry/rules/encryption/tink/aes_siv.ts
+++ b/schemaregistry/rules/encryption/tink/aes_siv.ts
@@ -13,27 +13,27 @@ import {SIV, SoftCryptoProvider} from "@hackbg/miscreant-esm";
  *
  */
 export class AesSiv extends Aead {
-  constructor(private readonly key: Uint8Array) {
+  constructor(private readonly key: Uint8Array<ArrayBuffer>) {
     super();
   }
 
   /**
    */
-  async encrypt(plaintext: Uint8Array, associatedData?: Uint8Array):
-      Promise<Uint8Array> {
+  async encrypt(plaintext: Uint8Array<ArrayBuffer>, associatedData?: Uint8Array<ArrayBuffer>):
+      Promise<Uint8Array<ArrayBuffer>> {
     let key = await SIV.importKey(this.key, "AES-CMAC-SIV", new SoftCryptoProvider());
     return key.seal(plaintext, associatedData != null ? [associatedData] : []);
   }
 
   /**
    */
-  async decrypt(ciphertext: Uint8Array, associatedData?: Uint8Array):
-      Promise<Uint8Array> {
+  async decrypt(ciphertext: Uint8Array<ArrayBuffer>, associatedData?: Uint8Array<ArrayBuffer>):
+      Promise<Uint8Array<ArrayBuffer>> {
     let key = await SIV.importKey(this.key, "AES-CMAC-SIV", new SoftCryptoProvider());
     return key.open(ciphertext, associatedData != null? [associatedData] : []);
   }
 }
 
-export async function fromRawKey(key: Uint8Array): Promise<Aead> {
+export async function fromRawKey(key: Uint8Array<ArrayBuffer>): Promise<Aead> {
   return new AesSiv(key);
 }

--- a/schemaregistry/rules/encryption/tink/bytes.ts
+++ b/schemaregistry/rules/encryption/tink/bytes.ts
@@ -11,7 +11,7 @@ import {InvalidArgumentsException} from './exception/invalid_arguments_exception
  * @param ba2 - The second bytearray to check.
  * @returns If the array are equal.
  */
-export function isEqual(ba1: Uint8Array, ba2: Uint8Array): boolean {
+export function isEqual(ba1: Uint8Array<ArrayBuffer>, ba2: Uint8Array<ArrayBuffer>): boolean {
   if (ba1.length !== ba2.length) {
     return false;
   }
@@ -25,7 +25,7 @@ export function isEqual(ba1: Uint8Array, ba2: Uint8Array): boolean {
 /**
  * Returns a new array that is the result of joining the arguments.
  */
-export function concat(...var_args: Uint8Array[]): Uint8Array {
+export function concat(...var_args: Uint8Array<ArrayBuffer>[]): Uint8Array<ArrayBuffer> {
   let length = 0;
   for (let i = 0; i < arguments.length; i++) {
     // eslint-disable-next-line prefer-rest-params
@@ -48,7 +48,7 @@ export function concat(...var_args: Uint8Array[]): Uint8Array {
  * @returns The number as a big-endian byte array.
  * @throws {@link InvalidArgumentsException}
  */
-export function fromNumber(value: number): Uint8Array {
+export function fromNumber(value: number): Uint8Array<ArrayBuffer> {
   if (Number.isNaN(value) || value % 1 !== 0) {
     throw new InvalidArgumentsException('cannot convert non-integer value');
   }
@@ -81,7 +81,7 @@ export function fromNumber(value: number): Uint8Array {
  * @returns the byte array output
  * @throws {@link InvalidArgumentsException}
  */
-export function fromHex(hex: string): Uint8Array {
+export function fromHex(hex: string): Uint8Array<ArrayBuffer> {
   if (hex.length % 2 != 0) {
     throw new InvalidArgumentsException(
         'Hex string length must be multiple of 2');
@@ -99,7 +99,7 @@ export function fromHex(hex: string): Uint8Array {
  * @param bytes - the byte array input
  * @returns hex the output
  */
-export function toHex(bytes: Uint8Array): string {
+export function toHex(bytes: Uint8Array<ArrayBuffer>): string {
   let result = '';
   for (let i = 0; i < bytes.length; i++) {
     const hexByte = bytes[i].toString(16);
@@ -116,7 +116,7 @@ export function toHex(bytes: Uint8Array): string {
  *     alphabet, which does not require escaping for use in URLs.
  * @returns the byte array output
  */
-export function fromBase64(encoded: string, opt_webSafe?: boolean): Uint8Array {
+export function fromBase64(encoded: string, opt_webSafe?: boolean): Uint8Array<ArrayBuffer> {
   if (opt_webSafe) {
     const normalBase64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
     return fromByteString(window.atob(normalBase64));
@@ -132,7 +132,7 @@ export function fromBase64(encoded: string, opt_webSafe?: boolean): Uint8Array {
  *     alphabet, which does not require escaping for use in URLs.
  * @returns base64 output
  */
-export function toBase64(bytes: Uint8Array, opt_webSafe?: boolean): string {
+export function toBase64(bytes: Uint8Array<ArrayBuffer>, opt_webSafe?: boolean): string {
   const encoded = window
                       .btoa(
                           /* padding */
@@ -151,7 +151,7 @@ export function toBase64(bytes: Uint8Array, opt_webSafe?: boolean): string {
  * @param str - the input
  * @returns the byte array output
  */
-export function fromByteString(str: string): Uint8Array {
+export function fromByteString(str: string): Uint8Array<ArrayBuffer> {
   const output = [];
   let p = 0;
   for (let i = 0; i < str.length; i++) {
@@ -170,7 +170,7 @@ export function fromByteString(str: string): Uint8Array {
  *     characters.
  * @returns Stringification of the array.
  */
-export function toByteString(bytes: Uint8Array): string {
+export function toByteString(bytes: Uint8Array<ArrayBuffer>): string {
   let str = '';
   for (let i = 0; i < bytes.length; i += 1) {
     str += String.fromCharCode(bytes[i]);

--- a/schemaregistry/rules/encryption/tink/hkdf.ts
+++ b/schemaregistry/rules/encryption/tink/hkdf.ts
@@ -28,8 +28,8 @@ import * as Validators from './validators';
  * @returns Output keying material (okm).
  */
 export async function compute(
-    size: number, hash: string, ikm: Uint8Array, info: Uint8Array,
-    opt_salt?: Uint8Array): Promise<Uint8Array> {
+    size: number, hash: string, ikm: Uint8Array<ArrayBuffer>, info: Uint8Array<ArrayBuffer>,
+    opt_salt?: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
   let digestSize;
   if (!Number.isInteger(size)) {
     throw new InvalidArgumentsException('size must be an integer');

--- a/schemaregistry/rules/encryption/tink/hmac.ts
+++ b/schemaregistry/rules/encryption/tink/hmac.ts
@@ -33,7 +33,7 @@ export class Hmac extends Mac {
 
   /**
    */
-  async computeMac(data: Uint8Array): Promise<Uint8Array> {
+  async computeMac(data: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
     Validators.requireUint8Array(data);
     const tag = await crypto.subtle.sign(
         {'name': 'HMAC', 'hash': {'name': this.hash}}, this.key, data);
@@ -42,7 +42,7 @@ export class Hmac extends Mac {
 
   /**
    */
-  async verifyMac(tag: Uint8Array, data: Uint8Array): Promise<boolean> {
+  async verifyMac(tag: Uint8Array<ArrayBuffer>, data: Uint8Array<ArrayBuffer>): Promise<boolean> {
     Validators.requireUint8Array(tag);
     Validators.requireUint8Array(data);
     const computedTag = await this.computeMac(data);
@@ -55,7 +55,7 @@ export class Hmac extends Mac {
  * @param tagSize - the size of the tag
  */
 export async function fromRawKey(
-    hash: string, key: Uint8Array, tagSize: number): Promise<Mac> {
+    hash: string, key: Uint8Array<ArrayBuffer>, tagSize: number): Promise<Mac> {
   Validators.requireUint8Array(key);
   if (!Number.isInteger(tagSize)) {
     throw new InvalidArgumentsException('invalid tag size, must be an integer');

--- a/schemaregistry/rules/encryption/tink/mac.ts
+++ b/schemaregistry/rules/encryption/tink/mac.ts
@@ -21,7 +21,7 @@ export abstract class Mac {
    * @param data - the data to compute MAC
    * @returns the MAC tag
    */
-  abstract computeMac(data: Uint8Array): Promise<Uint8Array>;
+  abstract computeMac(data: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>>;
 
   /**
    * Verifies whether `tag` is a correct authentication code for `data`.
@@ -29,5 +29,5 @@ export abstract class Mac {
    * @param tag - the MAC tag
    * @param data - the data to compute MAC
    */
-  abstract verifyMac(tag: Uint8Array, data: Uint8Array): Promise<boolean>;
+  abstract verifyMac(tag: Uint8Array<ArrayBuffer>, data: Uint8Array<ArrayBuffer>): Promise<boolean>;
 }

--- a/schemaregistry/rules/encryption/tink/random.ts
+++ b/schemaregistry/rules/encryption/tink/random.ts
@@ -16,7 +16,7 @@ import * as crypto from 'crypto';
  * @param n - number of bytes to generate
  * @returns the random bytes
  */
-export function randBytes(n: number): Uint8Array {
+export function randBytes(n: number): Uint8Array<ArrayBuffer> {
   if (!Number.isInteger(n) || n < 0) {
     throw new InvalidArgumentsException('n must be a nonnegative integer');
   }

--- a/schemaregistry/rules/encryption/tink/validators.ts
+++ b/schemaregistry/rules/encryption/tink/validators.ts
@@ -25,7 +25,7 @@ export function validateAesKeySize(n: number) {
  *
  * @throws {@link InvalidArgumentsException}
  */
-export function requireUint8Array(input: Uint8Array) {
+export function requireUint8Array(input: Uint8Array<ArrayBuffer>) {
   if (input == null || !(input instanceof Uint8Array)) {
     throw new InvalidArgumentsException('input must be a non null Uint8Array');
   }


### PR DESCRIPTION
This PR updates the repository from TypeScript 5.6 to 5.9.

TypeScript 5.9 includes [breaking changes to lib.d.ts](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#notable-behavioral-changes), forcing us to change some types for some functions from `Uint8Array `to `Uint8Array<ArrayBuffer>`.

The rationale for this change in TypeScript is explained in https://github.com/microsoft/TypeScript/pull/59417: Some APIs accept typed arrays backed by a SharedArrayBuffer, while others only accept ArrayBuffer, and the new version of TypeScript checks the types. 

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
