### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -52,4 +52,4 @@ util.dictToStringList = function (mapOrObject) {
   return list;
 };
 
-util.bindingVersion = '1.5.0-rc1';
+util.bindingVersion = '1.5.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@confluentinc/kafka-javascript",
-  "version": "1.5.0-rc1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@confluentinc/kafka-javascript",
-      "version": "1.5.0-rc1",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -11889,7 +11889,7 @@
     },
     "schemaregistry": {
       "name": "@confluentinc/schemaregistry",
-      "version": "1.5.0-rc1",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.637.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confluentinc/kafka-javascript",
-  "version": "1.5.0-rc1",
+  "version": "1.5.0",
   "description": "Node.js bindings for librdkafka",
   "librdkafka": "2.11.1",
   "librdkafka_win": "2.11.1",

--- a/schemaregistry/package.json
+++ b/schemaregistry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confluentinc/schemaregistry",
-  "version": "1.5.0-rc1",
+  "version": "1.5.0",
   "description": "Node.js client for Confluent Schema Registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
RC postinstall: https://semaphore.ci.confluent.io/workflows/3c71bee4-70c6-42b5-8cfe-4d822d4aa422 (failures are due to npm not caching/serving release properly)