### PR TITLE
DGS-22899 Fix support for wrapped Avro unions

### DIFF
--- a/schemaregistry/test/serde/avro.spec.ts
+++ b/schemaregistry/test/serde/avro.spec.ts
@@ -357,6 +357,61 @@ const complexNestedSchema = `
   ]
 }`;
 
+const wrappedUnionSchema = `{
+  "fields": [
+    {
+      "name": "id",
+      "type": "int"
+    },
+    {
+      "name": "result",
+      "type": [
+        "null",
+        {
+          "fields": [
+            {
+              "name": "code",
+              "type": "int"
+            },
+            {
+              "confluent:tags": [
+                "PII"
+              ],
+              "name": "secret",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          ],
+          "name": "Data",
+          "type": "record"
+        },
+        {
+          "fields": [
+            {
+              "name": "code",
+              "type": "int"
+            },
+            {
+              "name": "reason",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          ],
+          "name": "Error",
+          "type": "record"
+        }
+      ]
+    }
+  ],
+  "name": "Result",
+  "namespace": "com.acme",
+  "type": "record"
+}`;
+
 class FakeClock extends Clock {
   fixedNow: number = 0
 
@@ -1472,6 +1527,71 @@ describe('AvroSerializer', () => {
     obj2 = await deser.deserialize(topic, bytes)
     expect(obj2.stringField).not.toEqual("hi");
     expect(obj2.bytesField).not.toEqual(Buffer.from([1, 2]));
+  })
+  it('basic encryption with wrapped union', async () => {
+    let conf: ClientConfig = {
+      baseURLs: [baseURL],
+      cacheCapacity: 1000
+    }
+    let client = SchemaRegistryClient.newClient(conf)
+    let serConfig: AvroSerializerConfig = {
+      useLatestVersion: true,
+      ruleConfig: {
+        secret: 'mysecret'
+      }
+    }
+    let ser = new AvroSerializer(client, SerdeType.VALUE, serConfig)
+    let dekClient = fieldEncryptionExecutor.executor.client!
+
+    let encRule: Rule = {
+      name: 'test-encrypt',
+      kind: 'TRANSFORM',
+      mode: RuleMode.WRITEREAD,
+      type: 'ENCRYPT',
+      tags: ['PII'],
+      params: {
+        'encrypt.kek.name': 'kek1',
+        'encrypt.kms.type': 'local-kms',
+        'encrypt.kms.key.id': 'mykey',
+      },
+      onFailure: 'ERROR,NONE'
+    }
+    let ruleSet: RuleSet = {
+      domainRules: [encRule]
+    }
+
+    let info: SchemaInfo = {
+      schemaType: 'AVRO',
+      schema: wrappedUnionSchema,
+      ruleSet
+    }
+
+    await client.register(subject, info, false)
+
+    let obj = {
+      id: 123,
+      result: {
+        'com.acme.Data': {
+          code: 456,
+          secret: 'mypii'
+        }
+      }
+    }
+    let bytes = await ser.serialize(topic, obj)
+
+    // reset encrypted field
+    obj.result["com.acme.Data"].secret = 'mypii'
+
+    let deserConfig: AvroDeserializerConfig = {
+      ruleConfig: {
+        secret: 'mysecret'
+      }
+    }
+    let deser = new AvroDeserializer(client, SerdeType.VALUE, deserConfig)
+    fieldEncryptionExecutor.executor.client = dekClient
+    let obj2 = await deser.deserialize(topic, bytes)
+    expect(obj2.result["com.acme.Data"].code).toEqual(obj.result["com.acme.Data"].code);
+    expect(obj2.result["com.acme.Data"].secret).toEqual(obj.result["com.acme.Data"].secret);
   })
   it('basic encryption with logical type', async () => {
     let conf: ClientConfig = {


### PR DESCRIPTION
Fix support for wrapped Avro unions.  For ambiguous unions, the input will be a wrapped union, i.e. a map with the name being the type name and the value being the union value.

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [Y] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [Y] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
