### PR TITLE
Generate  v1.8.0-rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# confluent-kafka-javascript 1.8.0-rc1
+
+v1.8.0-rc1 is a release candidate. It is supported for testing and evaluation purposes.
+
+## Enhancements
+
+1. References librdkafka v2.13.0-RC1. Refer to the [librdkafka v2.13.0-RC1 release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.13.0-RC1) for more information.
+2. Export CelExecutor/CelFieldExecutor in schemaregistry index.ts (#412).
+3. Minor improvement to rule failure message (#419).
+
+## Fixes
+
+1. fix(deps): update dependency validator to v13.15.22 [security] (#413).
+
 # confluent-kafka-javascript 1.7.0
 
 v1.7.0 is a feature release. It is supported for all usage.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ For guidelines on contributing please see [CONTRIBUTING.md](CONTRIBUTING.md)
 | 1.5.0                      | 2.11.1     |
 | 1.6.0                      | 2.12.0     |
 | 1.7.0                      | 2.12.1     |
+| 1.8.0                      | 2.13.0-RC1 |
 
 This mapping is applicable if you're using a pre-built binary. Otherwise, you can check the librdkafka version with the following command:
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -28,7 +28,7 @@ LibrdKafkaError.wrap = errorWrap;
  * @constant
  * @memberof RdKafka
  */
-// ====== Generated from librdkafka 2.12.1 file src-cpp/rdkafkacpp.h ======
+// ====== Generated from librdkafka 2.13.0-RC1 file src-cpp/rdkafkacpp.h ======
 LibrdKafkaError.codes = {
 
   /* Internal errors to rdkafka: */

--- a/lib/util.js
+++ b/lib/util.js
@@ -52,4 +52,4 @@ util.dictToStringList = function (mapOrObject) {
   return list;
 };
 
-util.bindingVersion = '1.7.0';
+util.bindingVersion = '1.8.0-rc1';

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@confluentinc/kafka-javascript",
-  "version": "1.7.0",
+  "version": "1.8.0-rc1",
   "description": "Node.js bindings for librdkafka",
-  "librdkafka": "2.12.1",
-  "librdkafka_win": "2.12.1",
+  "librdkafka": "2.13.0-RC1",
+  "librdkafka_win": "2.13.0-RC1",
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "scripts": {

--- a/schemaregistry/package.json
+++ b/schemaregistry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confluentinc/schemaregistry",
-  "version": "1.7.0",
+  "version": "1.8.0-rc1",
   "description": "Node.js client for Confluent Schema Registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -1,4 +1,4 @@
-// ====== Generated from librdkafka 2.12.1 file CONFIGURATION.md ======
+// ====== Generated from librdkafka 2.13.0-RC1 file CONFIGURATION.md ======
 // Code that generated this is a derivative work of the code from Nam Nguyen
 // https://gist.github.com/ntgn81/066c2c8ec5b4238f85d1e9168a04e3fb
 

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -1,4 +1,4 @@
-// ====== Generated from librdkafka 2.12.1 file src-cpp/rdkafkacpp.h ======
+// ====== Generated from librdkafka 2.13.0-RC1 file src-cpp/rdkafkacpp.h ======
 export const CODES: { ERRORS: {
   /* Internal errors to rdkafka: */
   /** Begin internal error codes (**-200**) */


### PR DESCRIPTION
This pull request prepares the codebase for the `1.8.0-rc1` release candidate of `confluent-kafka-javascript`, updating dependencies, version numbers, and documentation to reflect the new release and its reliance on `librdkafka v2.13.0-RC1`. 