### PR TITLE
Fix CompressionTypes.Snappy naming for KafkaJS compatibility

### DIFF
--- a/lib/kafkajs/_common.js
+++ b/lib/kafkajs/_common.js
@@ -244,7 +244,7 @@ const CompatibilityErrorMessages = Object.freeze({
   sendOptionsAcks: (fn) =>
     createReplacementErrorMessage('producer', fn, 'acks', 'acks: <number>', 'acks: <number>', false),
   sendOptionsCompression: (fn) =>
-    createReplacementErrorMessage('producer', fn, 'compression', 'compression: <type>', 'compression: CompressionTypes.GZIP|SNAPPY|LZ4|ZSTD', false),
+    createReplacementErrorMessage('producer', fn, 'compression', 'compression: <type>', 'compression: CompressionTypes.GZIP|Snappy|LZ4|ZSTD', false),
   sendOptionsTimeout: (fn) =>
     createReplacementErrorMessage('producer', fn, 'timeout', 'timeout: <number>', 'timeout: <number>', false),
   sendBatchMandatoryMissing: () =>

--- a/lib/kafkajs/_producer.js
+++ b/lib/kafkajs/_producer.js
@@ -34,7 +34,7 @@ const ProducerState = Object.freeze({
 const CompressionTypes = {
   None: 'none',
   GZIP: 'gzip',
-  SNAPPY: 'snappy',
+  Snappy: 'snappy',
   LZ4: 'lz4',
   ZSTD: 'zstd',
 };


### PR DESCRIPTION
## Summary
- Rename `SNAPPY` to `Snappy` in `CompressionTypes` enum to match the original KafkaJS API naming convention
- Fixes mismatch between TypeScript types (`types/kafkajs.d.ts`) and JavaScript implementation (`lib/kafkajs/_producer.js`)
