### PR TITLE
[APPSEC-6902] Replace npm install with npm ci in Semaphore CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ npm-debug.log
 
 docs
 
-examples/**/package-lock.json
-
 deps/*
 !deps/*.gyp
 !deps/windows-install.*

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -143,7 +143,7 @@ blocks:
           type: s1-prod-ubuntu24-04-amd64-1
       prologue:
         commands:
-          - npm install
+          - npm ci
           - cd schemaregistry
       jobs:
         - name: "Test"
@@ -190,7 +190,7 @@ blocks:
             - docker compose -f test/docker/docker-compose.yml up -d && sleep 30
             - export NODE_OPTIONS='--max-old-space-size=1536'
             - cd examples/performance
-            - npm install
+            - npm ci
             - bash -c '../../ci/tests/run_perf_test.sh'
             - rm -rf ./node_modules
 

--- a/examples/performance/package-lock.json
+++ b/examples/performance/package-lock.json
@@ -1,0 +1,70 @@
+{
+  "name": "performance",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "performance",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@confluentinc/kafka-javascript": "file:../..",
+        "kafkajs": "^2.2.4"
+      }
+    },
+    "../..": {
+      "name": "@confluentinc/kafka-javascript",
+      "version": "1.9.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "schemaregistry",
+        "schemaregistry-examples"
+      ],
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^2.0.3",
+        "bindings": "^1.3.1",
+        "nan": "^2.22.0"
+      },
+      "devDependencies": {
+        "@bufbuild/buf": "^1.37.0",
+        "@bufbuild/protoc-gen-es": "^2.0.0",
+        "@eslint/js": "^9.9.0",
+        "@hapi/boom": "^10.0.1",
+        "@types/eslint__js": "^8.42.3",
+        "@types/jest": "^29.5.13",
+        "@types/node": "^20.16.1",
+        "axios-mock-adapter": "^2.1.0",
+        "bluebird": "^3.5.3",
+        "eslint": "^8.57.0",
+        "eslint-plugin-jest": "^28.6.0",
+        "jest": "^29.7.0",
+        "jsdoc": "^4.0.2",
+        "mocha": "^10.7.0",
+        "node-gyp": "^11.0.0",
+        "nyc": "^17.1.0",
+        "ts-jest": "^29.2.5",
+        "typescript": "^5.9.2",
+        "typescript-eslint": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@confluentinc/kafka-javascript": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/kafkajs": {
+      "version": "2.2.4",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/kafkajs/-/kafkajs-2.2.4.tgz",
+      "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Replaces bare `npm install` with `npm ci` in Semaphore CI configs
- `npm ci` installs strictly from `package-lock.json` and fails on any mismatch, ensuring reproducible CI builds
- This change will act as a mitigation against malicious dependencies being pulled into CI

## Test plan
- [ ] Verify Semaphore CI pipeline passes with `npm ci`
- [ ] Confirm `package-lock.json` is committed and up-to-date

🤖 Generated with [Claude Code](https://claude.com/claude-code)