### PR TITLE
[fix] pass string as first arg to user logger on error events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 5. Correct the TypeScript `FetchOffsetsPartition.error` type returned by `admin.fetchOffsets` to `LibrdKafkaError | null`, matching the runtime which always populates the field. It never returnes undefined. (#489)
 6. Correct broken "types" path so TS consumers get types (#484)
 7. Resolve IHeaders import for installed clients (#492)
+8. Fix error callback passing and object to the logger instead of a string (#483)
 
 
 # confluent-kafka-javascript 1.9.0

--- a/lib/kafkajs/_admin.js
+++ b/lib/kafkajs/_admin.js
@@ -195,7 +195,7 @@ class Admin {
   }
 
   /**
-   * Callback for the event.error event, either fails the initial connect(), or logs the error.
+   * Callback for the event.error event, fails the initial connect() and logs the error.
    * @param {Error} err
    * @private
    */

--- a/lib/kafkajs/_admin.js
+++ b/lib/kafkajs/_admin.js
@@ -204,9 +204,8 @@ class Admin {
     if (this.#state < AdminState.CONNECTED) {
       if (!this.#connectionError)
         this.#connectionError = err;
-    } else {
-      this.#logger.error(`Error: ${err.message}`, this.#createAdminBindingMessageMetadata());
     }
+    this.#logger.error(`Error: ${err.message}`, this.#createAdminBindingMessageMetadata());
   }
 
   /**

--- a/lib/kafkajs/_common.js
+++ b/lib/kafkajs/_common.js
@@ -130,7 +130,7 @@ class DefaultLogger {
  */
 function createBindingMessageMetadata(clientName) {
   return {
-    name: clientName,
+    name: clientName || '',
     fac: 'BINDING',
     timestamp: Date.now(),
   };

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -774,9 +774,8 @@ class Consumer {
     if (this.#state < ConsumerState.CONNECTED) {
       if (!this.#connectionError)
         this.#connectionError = err;
-    } else {
-      this.#logger.error(err, this.#createConsumerBindingMessageMetadata());
     }
+    this.#logger.error(`Error: ${err.message}`, this.#createConsumerBindingMessageMetadata());
   }
 
 

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -765,7 +765,7 @@ class Consumer {
   }
 
   /**
-   * Callback for the event.error event, either fails the initial connect(), or logs the error.
+   * Callback for the event.error event, fails the initial connect() and logs the error.
    * @param {Error} err
    * @private
    */

--- a/lib/kafkajs/_producer.js
+++ b/lib/kafkajs/_producer.js
@@ -376,7 +376,7 @@ class Producer {
       if (!this.#connectionError)
         this.#connectionError = err;
     }
-    this.#logger.error(err, this.#createProducerBindingMessageMetadata());
+    this.#logger.error(`Error: ${err.message}`, this.#createProducerBindingMessageMetadata());
   }
 
   /**

--- a/lib/kafkajs/_producer.js
+++ b/lib/kafkajs/_producer.js
@@ -366,7 +366,7 @@ class Producer {
   }
 
   /**
-   * Callback for the event.error event, either fails the initial connect(), or logs the error.
+   * Callback for the event.error event, fails the initial connect() and logs the error.
    * @param {Error} err
    * @private
    */

--- a/test/promisified/unit/logger.spec.js
+++ b/test/promisified/unit/logger.spec.js
@@ -50,7 +50,6 @@ jest.mock('../../../lib/rdkafka', () => {
 const { Kafka } = require('../../../lib/kafkajs');
 const LibrdKafkaError = require('../../../lib/error');
 const RdKafkaMock = require('../../../lib/rdkafka');
-const { timeStamp } = require('console');
 
 function makeLogger() {
   const logger = {
@@ -65,13 +64,13 @@ function makeLogger() {
 }
 
 function brokerError() {
-  return LibrdKafkaError.create(new Error('local: broker transport failure'));
+  return LibrdKafkaError.create(new Error('Local: broker transport failure'));
 }
 
-function expectStringFirstArg(mockFn) {
+function expectStringFirstArg(mockFn, err) {
   expect(mockFn).toHaveBeenCalled();
   const [firstArg, secondArg] = mockFn.mock.calls[mockFn.mock.calls.length - 1];
-  expect(typeof firstArg).toBe('string');
+  expect(firstArg).toEqual(`Error: ${err.message}`);
   expect(secondArg).toEqual(expect.objectContaining({
     fac: 'BINDING',
     name: expect.any(String),
@@ -79,7 +78,7 @@ function expectStringFirstArg(mockFn) {
   }));
 }
 
-describe('user-supplied logger receives a string as the first arg on event.error', () => {
+describe('user-supplied logger receives a string as the first arg on error callbacks', () => {
   beforeEach(() => {
     RdKafkaMock.__captured.producer = null;
     RdKafkaMock.__captured.consumer = null;
@@ -91,9 +90,10 @@ describe('user-supplied logger receives a string as the first arg on event.error
     const producer = new Kafka({ kafkaJS: { brokers: ['x:1'], logger } }).producer();
     producer.connect().catch(() => {});
 
-    RdKafkaMock.__captured.producer.emit('event.error', brokerError());
+    const err = brokerError();
+    RdKafkaMock.__captured.producer.emit('event.error', err);
 
-    expectStringFirstArg(logger.error);
+    expectStringFirstArg(logger.error, err);
   });
 
   it('Consumer #errorCb passes a string to logger.error', async () => {
@@ -102,9 +102,10 @@ describe('user-supplied logger receives a string as the first arg on event.error
     const consumer = kafka.consumer({ kafkaJS: { groupId: 'g' } });
     consumer.connect().catch(() => {});
 
-    RdKafkaMock.__captured.consumer.emit('event.error', brokerError());
+    const err = brokerError();
+    RdKafkaMock.__captured.consumer.emit('event.error', err);
 
-    expectStringFirstArg(logger.error);
+    expectStringFirstArg(logger.error, err);
   });
 
   it('Admin #errorCb passes a string to logger.error', async () => {
@@ -112,8 +113,9 @@ describe('user-supplied logger receives a string as the first arg on event.error
     const admin = new Kafka({ kafkaJS: { brokers: ['x:1'], logger } }).admin();
     await admin.connect();
 
-    RdKafkaMock.__captured.admin._listeners.error(brokerError());
+    const err = brokerError();
+    RdKafkaMock.__captured.admin._listeners.error(err);
 
-    expectStringFirstArg(logger.error);
+    expectStringFirstArg(logger.error, err);
   });
 });

--- a/test/promisified/unit/logger.spec.js
+++ b/test/promisified/unit/logger.spec.js
@@ -1,0 +1,119 @@
+jest.mock('../../../lib/rdkafka', () => {
+  const { EventEmitter } = require('events');
+
+  function makeStubClient(name) {
+    const client = new EventEmitter();
+    client.name = name;
+    client.connect = jest.fn();
+    client.disconnect = jest.fn();
+    client.setPollInBackground = jest.fn();
+    client.setDefaultIsTimeoutOnlyForFirstMessage = jest.fn();
+    client.setDefaultConsumeTimeout = jest.fn();
+    return client;
+  }
+
+  const captured = { producer: null, consumer: null, admin: null };
+
+  function ProducerCtor() {
+    captured.producer = makeStubClient('rdkafka#producer-test');
+    return captured.producer;
+  }
+
+  function KafkaConsumerCtor() {
+    captured.consumer = makeStubClient('rdkafka#consumer-test');
+    return captured.consumer;
+  }
+
+  return {
+    Producer: ProducerCtor,
+    KafkaConsumer: KafkaConsumerCtor,
+    AdminClient: {
+      create: jest.fn((_config, listeners) => {
+        const stub = {
+          name: 'rdkafka#admin-test',
+          on: jest.fn(),
+          disconnect: jest.fn(),
+          _listeners: listeners,
+        };
+        captured.admin = stub;
+        if (listeners && typeof listeners.ready === 'function') {
+          listeners.ready();
+        }
+        return stub;
+      }),
+    },
+    CODES: { ERRORS: {} },
+    __captured: captured,
+  };
+});
+
+const { Kafka } = require('../../../lib/kafkajs');
+const LibrdKafkaError = require('../../../lib/error');
+const RdKafkaMock = require('../../../lib/rdkafka');
+const { timeStamp } = require('console');
+
+function makeLogger() {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    setLogLevel: jest.fn(),
+  };
+  logger.namespace = jest.fn(() => logger);
+  return logger;
+}
+
+function brokerError() {
+  return LibrdKafkaError.create(new Error('local: broker transport failure'));
+}
+
+function expectStringFirstArg(mockFn) {
+  expect(mockFn).toHaveBeenCalled();
+  const [firstArg, secondArg] = mockFn.mock.calls[mockFn.mock.calls.length - 1];
+  expect(typeof firstArg).toBe('string');
+  expect(secondArg).toEqual(expect.objectContaining({
+    fac: 'BINDING',
+    name: expect.any(String),
+    timestamp: expect.any(Number),
+  }));
+}
+
+describe('user-supplied logger receives a string as the first arg on event.error', () => {
+  beforeEach(() => {
+    RdKafkaMock.__captured.producer = null;
+    RdKafkaMock.__captured.consumer = null;
+    RdKafkaMock.__captured.admin = null;
+  });
+
+  it('Producer #errorCb passes a string to logger.error', async () => {
+    const logger = makeLogger();
+    const producer = new Kafka({ kafkaJS: { brokers: ['x:1'], logger } }).producer();
+    producer.connect().catch(() => {});
+
+    RdKafkaMock.__captured.producer.emit('event.error', brokerError());
+
+    expectStringFirstArg(logger.error);
+  });
+
+  it('Consumer #errorCb passes a string to logger.error', async () => {
+    const logger = makeLogger();
+    const kafka = new Kafka({ kafkaJS: { brokers: ['x:1'], logger } });
+    const consumer = kafka.consumer({ kafkaJS: { groupId: 'g' } });
+    consumer.connect().catch(() => {});
+
+    RdKafkaMock.__captured.consumer.emit('event.error', brokerError());
+
+    expectStringFirstArg(logger.error);
+  });
+
+  it('Admin #errorCb passes a string to logger.error', async () => {
+    const logger = makeLogger();
+    const admin = new Kafka({ kafkaJS: { brokers: ['x:1'], logger } }).admin();
+    await admin.connect();
+
+    RdKafkaMock.__captured.admin._listeners.error(brokerError());
+
+    expectStringFirstArg(logger.error);
+  });
+});


### PR DESCRIPTION
The producer/consumer #errorCb forwarded the raw Error object as the first arg to the user-supplied logger, while admin used a string. Make all three pass `Error: ${err.message}`. Also always log on error (not only after CONNECTED) and default `name` in binding metadata to '' when the client name is not yet available. Add unit test covering all three.