### PR TITLE
fix(package.json): correct broken "types" path so TS consumers get types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "librdkafka": "2.14.0",
   "librdkafka_win": "2.14.0",
   "main": "lib/index.js",
-  "types": "types/index.d.ts",
+  "types": "index.d.ts",
   "scripts": {
     "configure": "node-gyp configure",
     "build": "node-gyp build",


### PR DESCRIPTION
## Summary

Fixes #403.

`package.json` advertises

```json
"types": "types/index.d.ts"
```

but that file does not exist in the published package or in the repo. The actual type entry is the top-level `index.d.ts`, which re-exports the per-module declarations:

```ts
// index.d.ts (repo root)
export * from './types/rdkafka';
export * as RdKafka from './types/rdkafka';
export * as KafkaJS from './types/kafkajs';
```

## Impact

With the current `types` path pointing at a non-existent file, TypeScript consumers of `@confluentinc/kafka-javascript` get **no types at all** when they `import { ... } from '@confluentinc/kafka-javascript'` — they see `any` everywhere. Workarounds in the wild include `"paths"` shims or direct deep imports from `node_modules/.../types/rdkafka`, neither of which should be necessary. Maintainer @PratRanj07 acknowledged the bug in #403 (internal ticket 4253).

## Verification

On `master` today (2026-05-11):

```
curl -sI https://raw.githubusercontent.com/confluentinc/confluent-kafka-javascript/master/types/index.d.ts  → 404
curl -sI https://raw.githubusercontent.com/confluentinc/confluent-kafka-javascript/master/index.d.ts        → 200
```

The `types/` directory exists and contains `config.d.ts`, `errors.d.ts`, `kafkajs.d.ts`, `rdkafka.d.ts`, etc., but there is no `index.d.ts` inside it. The only `index.d.ts` in the repo is at the root.

## Fix

One-line change in `package.json`:

```diff
-  "types": "types/index.d.ts",
+  "types": "index.d.ts",
```

`index.d.ts` is already shipped (it lives at the repo root and is not in `.gitignore` / `files`-excluded), so no other changes are needed. After this fix, `tsc` resolves `@confluentinc/kafka-javascript` to the existing root `index.d.ts` and downstream users get the full `RdKafka` / `KafkaJS` types.

## Test plan

- [x] `curl` confirms `index.d.ts` exists and `types/index.d.ts` 404s on `master`
- [x] `npm pack --dry-run` (locally) shows `index.d.ts` is included in the tarball alongside `types/*.d.ts`
- [x] `test:types` script (`tsc -p .`) still passes (no source change — only the manifest pointer moved)
- [ ] CI green

Happy to add a small consumer smoke-test (`tsc --noEmit` against a tiny `import { KafkaJS } from '@confluentinc/kafka-javascript'` stub) if maintainers want a regression guard.
