### PR TITLE
fix(types): expose cooperative-sticky rebalance methods on KafkaConsumer

### DIFF
--- a/types/rdkafka.d.ts
+++ b/types/rdkafka.d.ts
@@ -216,6 +216,14 @@ export class KafkaConsumer extends Client<KafkaConsumerEvents> {
 
     assignments(): Assignment[];
 
+    /**
+     * Whether the current partition assignment was lost in the rebalance
+     * callback when partitions are revoked.
+     *
+     * Only meaningful when called from within the rebalance callback.
+     */
+    assignmentLost(): boolean;
+
     commit(topicPartition: TopicPartitionOffsetAndMetadata | TopicPartitionOffsetAndMetadata[]): this;
     commit(): this;
 
@@ -253,6 +261,28 @@ export class KafkaConsumer extends Client<KafkaConsumerEvents> {
     subscription(): string[];
 
     unassign(): this;
+
+    /**
+     * Incrementally add partitions to the consumer's current assignment.
+     * Required when using cooperative-sticky rebalancing — call from within
+     * the rebalance callback on `ERR__ASSIGN_PARTITIONS`.
+     */
+    incrementalAssign(assignments: Assignment[]): this;
+
+    /**
+     * Incrementally remove partitions from the consumer's current assignment.
+     * Required when using cooperative-sticky rebalancing — call from within
+     * the rebalance callback on `ERR__REVOKE_PARTITIONS`.
+     */
+    incrementalUnassign(assignments: Assignment[]): this;
+
+    /**
+     * Get the rebalance protocol in use by the consumer group.
+     *
+     * @returns "NONE" if not joined to a group yet, otherwise "COOPERATIVE"
+     *   or "EAGER".
+     */
+    rebalanceProtocol(): "NONE" | "COOPERATIVE" | "EAGER";
 
     unsubscribe(): this;
 


### PR DESCRIPTION
## Summary

Fixes #469.

When `partition.assignment.strategy=cooperative-sticky` is set, the rebalance callback needs to call **`incrementalAssign`** / **`incrementalUnassign`** instead of `assign` / `unassign`. The runtime exposes them (see `lib/kafka-consumer.js`):

```js
KafkaConsumer.prototype.incrementalAssign = function(assignments) { … };
KafkaConsumer.prototype.incrementalUnassign = function(assignments) { … };
KafkaConsumer.prototype.assignmentLost      = function()            { … };
KafkaConsumer.prototype.rebalanceProtocol   = function()            { … };
```

The stock rebalance handler in `lib/kafka-consumer.js` (lines 68-79) even branches on `rebalanceProtocol() === 'COOPERATIVE'` to call `incrementalAssign` / `incrementalUnassign`. But **none of those four methods are declared in `types/rdkafka.d.ts`**, so TypeScript consumers writing their own rebalance callback must fall back to `(consumer as any).incrementalAssign(...)` (the screenshot in #469 shows exactly this).

## Fix

Types-only change in `types/rdkafka.d.ts`. Added four method declarations on `KafkaConsumer`, each with a JSDoc block mirroring the runtime documentation in `lib/kafka-consumer.js`:

```ts
incrementalAssign(assignments: Assignment[]): this;
incrementalUnassign(assignments: Assignment[]): this;
assignmentLost(): boolean;
rebalanceProtocol(): "NONE" | "COOPERATIVE" | "EAGER";
```

- `Assignment` is the existing alias `TopicPartition | TopicPartitionOffset`, matching the `assign(...)` signature — the runtime maps both into `TopicPartition` via `TopicPartition.map(...)`.
- The `rebalanceProtocol()` return is constrained to the three literal strings the runtime can produce (`"NONE" | "COOPERATIVE" | "EAGER"`), so user code can do `if (c.rebalanceProtocol() === "COOPERATIVE")` without a string cast.
- `assignmentLost()` returns `boolean` per the JS doc (`@return {boolean} true if assignment was lost.`).

The original issue only mentions `incrementalAssign` / `incrementalUnassign`, but `assignmentLost` and `rebalanceProtocol` are part of the same cooperative-sticky workflow and have the same missing-types problem — happy to scope the PR back to just the two if maintainers prefer.

## Test plan

- [x] `tsc -p .` (the existing `npm run test:types` script) still passes — added declarations only.
- [x] Confirmed each method exists on the runtime prototype in `lib/kafka-consumer.js` (see lines 305–308, 319–322, 342–344, 351–353 on `master`).
- [x] Confirmed `assignmentLost` and `rebalanceProtocol` aren’t already declared anywhere else in `types/*.d.ts`.
- [ ] CI green.
