### PR TITLE
Correct the TypeScript return type of `admin.fetchTopicMetadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 1. Handle anyOf/allOf in JSON transforms (#479)
 2. Preserve custom subjectNameStrategy in serde constructors (#482)
+3. Correct the TypeScript return type of `admin.fetchTopicMetadata` to `Promise<Array<ITopicMetadata>> (#367)
 
 
 # confluent-kafka-javascript 1.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Fixes
 1. Handle anyOf/allOf in JSON transforms (#479)
 2. Preserve custom subjectNameStrategy in serde constructors (#482)
-3. Correct the TypeScript return type of `admin.fetchTopicMetadata` to `Promise<Array<ITopicMetadata>> (#367)
+3. Correct the TypeScript return type of `admin.fetchTopicMetadata` to `Promise<Array<ITopicMetadata>>` (#367)
 
 
 # confluent-kafka-javascript 1.9.0

--- a/lib/kafkajs/_admin.js
+++ b/lib/kafkajs/_admin.js
@@ -729,7 +729,7 @@ class Admin {
    * @param {boolean?} options.includeAuthorizedOperations - If true, include operations allowed on the topic
    *                                                         by the calling client (default: false).
    *
-   * @returns {Promise<{ topics: Array<object> }>}
+   * @returns {Promise<Array<object>>}
    */
   async fetchTopicMetadata(options = {}) {
     if (this.#state !== AdminState.CONNECTED) {

--- a/types/kafkajs.d.ts
+++ b/types/kafkajs.d.ts
@@ -455,7 +455,7 @@ export type Admin = {
     topics?: string[],
     includeAuthorizedOperations?: boolean,
     timeout?: number
-  }): Promise<{ topics: Array<ITopicMetadata> }>
+  }): Promise<Array<ITopicMetadata>>
   fetchTopicOffsets(topic: string,
     options?: {
       timeout?: number,


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
## Fix `fetchTopicMetadata` TS return type

- `admin.fetchTopicMetadata` has always returned `Array<ITopicMetadata>` at runtime
  (see `lib/kafkajs/_admin.js` — the implementation `resolve`s a bare array, and our
  own internal callers in `fetchTopicOffsets` / `fetchTopicOffsetsByTimestamp` already
  treat the result as an array). The TypeScript declaration in `types/kafkajs.d.ts`
  claimed `Promise<{ topics: Array<ITopicMetadata> }>`, which silently misled every
  TS consumer of the admin API. **Corrected to `Promise<Array<ITopicMetadata>>` so the
  type now matches what the function actually hands back.**
- Also fixed the matching JSDoc `@returns` annotation on the JS implementation, which
  carried the same wrapped-object lie.



Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?

- Existing promisified tests (`test/promisified/admin/fetch_topic_metadata.spec.js`)
  already pin the runtime contract — they assert `metadata.length` and index
  `metadata[0]` directly — so they continue to pass and now agree with the declared
  type instead of contradicting it.

References
----------
Github: Closes #367.

Test & Review
------------
No javascript changes. Just corrects typescript type to be truthy. Fixes longstanding public reported annoyance.
