### PR TITLE
[Typescript] Fix the typescript return type for admin.describeGroups()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. Handle anyOf/allOf in JSON transforms (#479)
 2. Preserve custom subjectNameStrategy in serde constructors (#482)
 3. Correct the TypeScript return type of `admin.fetchTopicMetadata` to `Promise<Array<ITopicMetadata>>` (#367)
+4. Correct the TypeScript `MemberDescription` shape returned by `admin.describeGroups` so `assignment`/`targetAssignment` wrap a `topicPartitions` array and `memberAssignment`/`memberMetadata` are nullable (#487)
 
 
 # confluent-kafka-javascript 1.9.0

--- a/types/rdkafka.d.ts
+++ b/types/rdkafka.d.ts
@@ -382,15 +382,25 @@ export enum AclOperationTypes {
     IDEMPOTENT_WRITE = 12,
 }
 
+export type MemberAssignment = {
+    topicPartitions: TopicPartition[]
+}
+
 export type MemberDescription = {
     clientHost: string
     clientId: string
     memberId: string
-    memberAssignment: Buffer
-    memberMetadata: Buffer
+    /**
+     * @deprecated Always null from the native binding; reserved for future use.
+     */
+    memberAssignment: Buffer | null
+    /**
+     * @deprecated Always null from the native binding; reserved for future use.
+     */
+    memberMetadata: Buffer | null
     groupInstanceId?: string,
-    assignment: TopicPartition[]
-    targetAssignment?: TopicPartition[]
+    assignment: MemberAssignment
+    targetAssignment?: MemberAssignment
 }
 
 export type Node = {


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Fix the typescript return type for admin.describeGroups():
  - Introduced MemberAssignment named type; fixed MemberDescription.assignment and targetAssignment to wrap a topicPartitions array (matching the C++ binding's actual shape per [src/common.cc:1024-1106]; marked memberAssignment/memberMetadata as Buffer | null with @deprecated JSDoc since the binding always sets them to null.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required
  - Typescript types-only change, just like was done for #486 

References
----------
Closes #487 

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
Makes the type annotations truthy so that typescript users will have fewer impedances using this client.