### PR TITLE
[Typescript] Improve types for isKafkaJSError

### DIFF
--- a/types/kafkajs.d.ts
+++ b/types/kafkajs.d.ts
@@ -470,7 +470,7 @@ export type Admin = {
 }
 
 
-export function isKafkaJSError(error: Error): boolean;
+export function isKafkaJSError(error: any): error is KafkaJSError;
 
 export const ErrorCodes: typeof CODES.ERRORS;
 


### PR DESCRIPTION
Change the input parameter's type from `Error` to `any`. Now you no longer have to write this to silence all type errors:

```typescript
try {
  // ...
} catch (e) {
  if (e instanceof Error && isKafkaJSError(e) {
    // ...
  }
}
```

Now you can simply write:

```typescript
try {
  // ...
} catch (e) {
  if (isKafkaJSError(e)) {
    // ...
  }
}
```

Declare it as a type predicate so that TypeScript understands that if the function returns `true` that it narrows the type to `KafkaJSError`.

Please prefix all TypeScript pull-requests with `[Typescript]`

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
