### PR TITLE
Add partition to HighLevelProducer callback

### DIFF
--- a/lib/producer/high-level-producer.js
+++ b/lib/producer/high-level-producer.js
@@ -159,7 +159,7 @@ function HighLevelProducer(conf, topicConf) {
   // Listen to all delivery reports to propagate elements with a _message_id to the emitter
   this.on('delivery-report', function(err, report) {
     if (report.opaque && report.opaque.__message_id !== undefined) {
-      self._hl.deliveryEmitter.emit(report.opaque.__message_id, err, report.offset);
+      self._hl.deliveryEmitter.emit(report.opaque.__message_id, err, report.offset, report.partition);
     }
   });
 
@@ -188,6 +188,8 @@ function HighLevelProducer(conf, topicConf) {
  * @param {number|null} timestamp - Timestamp to send with the message.
  * @param {object} headers - A list of custom key value pairs that provide message metadata.
  * @param {function} callback - Callback to call when the delivery report is recieved.
+ *   Called with (err, offset, partition), where partition is the partition
+ *   the message was actually produced to.
  * @throws {RdKafka.LibrdKafkaError} - Throws a librdkafka error if it failed.
  * @return {boolean} - Throws an error if it failed, or returns true if not.
  * @see RdKafka.Producer#produce
@@ -221,12 +223,12 @@ HighLevelProducer.prototype._modifiedProduce = function(topic, partition, messag
         v, k,
         timestamp, opaque, headers);
 
-      self._hl.deliveryEmitter.once(opaque.__message_id, function(err, offset) {
+      self._hl.deliveryEmitter.once(opaque.__message_id, function(err, offset, partition) {
         self._hl.pollingRef.decrement();
         setImmediate(function() {
           // Offset must be greater than or equal to 0 otherwise it is a null offset
           // Possibly because we have acks off
-          callback(err, offset >= 0 ? offset : null);
+          callback(err, offset >= 0 ? offset : null, partition);
         });
       });
 

--- a/test/producer/high-level-producer.spec.js
+++ b/test/producer/high-level-producer.spec.js
@@ -491,6 +491,29 @@ module.exports = {
           next();
         });
       },
+
+      'passes the partition from the delivery report to the callback': function(next) {
+        var v = 'foo';
+        var k = 'key';
+
+        client._oldProduce = function(topic, partition, value, key, timestamp, opaque) {
+          setImmediate(function() {
+            client.emit('delivery-report', null, {
+              topic: topic,
+              partition: 3,
+              offset: 42,
+              opaque: opaque,
+            });
+          });
+        };
+
+        client.produce('tawpic', 0, v, k, null, function(err, offset, partition) {
+          t.equal(err, null);
+          t.equal(offset, 42);
+          t.equal(partition, 3);
+          next();
+        });
+      },
     }
   },
 };

--- a/types/rdkafka.d.ts
+++ b/types/rdkafka.d.ts
@@ -288,8 +288,8 @@ export class Producer extends Client<KafkaProducerEvents> {
 }
 
 export class HighLevelProducer extends Producer {
-  produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, callback: (err: any, offset?: NumberNullUndefined) => void): any;
-  produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, headers: MessageHeader[], callback: (err: any, offset?: NumberNullUndefined) => void): any;
+  produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, callback: (err: any, offset?: NumberNullUndefined, partition?: NumberNullUndefined) => void): any;
+  produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, headers: MessageHeader[], callback: (err: any, offset?: NumberNullUndefined, partition?: NumberNullUndefined) => void): any;
 
   setKeySerializer(serializer: (key: any, cb: (err: any, key: MessageKey) => void) => void): void;
   setKeySerializer(serializer: (key: any) => MessageKey | Promise<MessageKey>): void;


### PR DESCRIPTION
## Summary

`HighLevelProducer`'s `produce()` callback only receives `(err, offset)`, even though the underlying `delivery-report` event already includes the `partition` the message landed in. So there's no way to know which partition a message went to (e.g. for observability/instrumentation) without separately subscribing to the raw `delivery-report` event and correlating it back to the `produce()` call.

The KafkaJS-compatible producer (`lib/kafkajs/_producer.js`) already extracts `report.partition` for its own delivery callback, so this brings `HighLevelProducer` in line with it.

## Changes

- `lib/producer/high-level-producer.js`: forward `report.partition` through the internal delivery emitter and into the `produce()` callback as a third argument (`callback(err, offset, partition)`), non-breaking for existing two-arg callbacks.
- `types/rdkafka.d.ts`: add optional `partition` to the `HighLevelProducer.produce()` callback type.
- `test/producer/high-level-producer.spec.js`: add a test that simulates a delivery report and asserts the partition is passed through to the callback.

Fixes #238

## Test plan

- [x] `mocha --ui exports test/producer/high-level-producer.spec.js` — 20/20 passing
- [x] `tsc -p .` — no type errors
