### PR TITLE
Pass connection metadata timeout config to connect() in KafkaJS

### DIFF
--- a/lib/kafkajs/_common.js
+++ b/lib/kafkajs/_common.js
@@ -396,13 +396,7 @@ function kafkaJSToRdKafkaConfig(config) {
     rdkafkaConfig["socket.timeout.ms"] = 300000;
   }
 
-  const connectionTimeout = config.connectionTimeout ?? 1000;
-  const authenticationTimeout = config.authenticationTimeout ?? 10000;
-  let totalConnectionTimeout = Number(connectionTimeout) + Number(authenticationTimeout);
-
-  /* The minimum value for socket.connection.setup.timeout.ms is 1000. */
-  totalConnectionTimeout = Math.max(totalConnectionTimeout, 1000);
-  rdkafkaConfig["socket.connection.setup.timeout.ms"] = totalConnectionTimeout;
+  rdkafkaConfig["socket.connection.setup.timeout.ms"] = getConnectMetadataTimeout(config);
 
   const retry = config.retry ?? {};
   const { maxRetryTime, initialRetryTime, factor, multiplier, restartOnFailure } = retry;
@@ -863,6 +857,14 @@ function partitionKey(topicPartition) {
   return topicPartition.topic + '|'+ (topicPartition.partition);
 }
 
+function getConnectMetadataTimeout(config) {
+  const connectionTimeout = config?.connectionTimeout ?? 1000;
+  const authenticationTimeout = config?.authenticationTimeout ?? 10000;
+
+  /* The minimum value for socket.connection.setup.timeout.ms is 1000. */
+  return Math.max(Number(connectionTimeout) + Number(authenticationTimeout), 1000);
+}
+
 module.exports = {
   kafkaJSToRdKafkaConfig,
   topicPartitionOffsetToRdKafka,
@@ -884,4 +886,5 @@ module.exports = {
   DeferredPromise,
   Timer,
   partitionKey,
+  getConnectMetadataTimeout,
 };

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -19,7 +19,8 @@ const {
   Lock,
   partitionKey,
   DeferredPromise,
-  Timer
+  Timer,
+  getConnectMetadataTimeout
 } = require('./_common');
 const { Buffer } = require('buffer');
 const MessageCache = require('./_consumer_cache');
@@ -1205,7 +1206,9 @@ class Consumer {
 
     return new Promise((resolve, reject) => {
       this.#connectPromiseFunc = { resolve, reject };
-      this.#internalClient.connect(null, (err) => {
+      this.#internalClient.connect(
+        { timeout: getConnectMetadataTimeout(this.#userConfig.kafkaJS) },
+        (err) => {
         if (err) {
           this.#state = ConsumerState.DISCONNECTED;
           const rejectionError = this.#connectionError ? this.#connectionError : err;

--- a/lib/kafkajs/_producer.js
+++ b/lib/kafkajs/_producer.js
@@ -11,6 +11,7 @@ const { kafkaJSToRdKafkaConfig,
   checkAllowedKeys,
   CompatibilityErrorMessages,
   logLevel,
+  getConnectMetadataTimeout,
 } = require('./_common');
 const error = require('./_error');
 const { Buffer } = require('buffer');
@@ -412,7 +413,9 @@ class Producer {
 
     return new Promise((resolve, reject) => {
       this.#connectPromiseFunc = { resolve, reject };
-      this.#internalClient.connect(null, (err) => {
+      this.#internalClient.connect(
+        { timeout: getConnectMetadataTimeout(this.#userConfig.kafkaJS) },
+        (err) => {
         if (err) {
           this.#state = ProducerState.DISCONNECTED;
           const rejectionError = this.#connectionError ? this.#connectionError : err;

--- a/test/promisified/unit/common.spec.js
+++ b/test/promisified/unit/common.spec.js
@@ -1,5 +1,12 @@
-const { Lock } = require('../../../lib/kafkajs/_common');
+const { Lock, getConnectMetadataTimeout } = require('../../../lib/kafkajs/_common');
 const { SequentialPromises } = require('../testhelpers');
+
+describe('getConnectMetadataTimeout', () => {
+  it('uses connectionTimeout + authenticationTimeout with a 1000ms minimum', () => {
+    expect(getConnectMetadataTimeout({ connectionTimeout: 1000, authenticationTimeout: 0 })).toStrictEqual(1000);
+    expect(getConnectMetadataTimeout({})).toStrictEqual(11000);
+  });
+});
 
 describe('Lock', () => {
 


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
The promisified consumer/producer calls the internal client with `connect(null)`, so metadata fetch always uses the native default of **30s** (`connection.cc` [line 413](https://github.com/confluentinc/confluent-kafka-javascript/blob/ca998ff55dea14b162a4763067e16275439be2f4/src/connection.cc#L413)). The client's `connectionTimeout` config only affects `socket.connection.setup.timeout.ms`, not the metadata timeout during `connect()`.

Is there a particular reason why connect() is passed a null config?

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
Unit test

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
