### PR TITLE
fix: track last consumed offset in eachBatch resolveOffset so pause() does not lose prefetched messages

### DIFF
--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -872,6 +872,11 @@ class Consumer {
     const partition = payload.batch.partition;
 
     payload._lastResolvedOffset = { offset, leaderEpoch };
+    /* As documented above, the last consumed offset must also be tracked so
+     * that a cache-clearing operation (e.g. pause()) can seek back to the
+     * first un-consumed message. Without this, the eachBatch path leaves the
+     * map unpopulated and pause() permanently loses whatever the cache held. */
+    this.#lastConsumedOffsets.set(partitionKey({ topic, partition }), { offset, leaderEpoch });
 
     try {
       this.#internalClient._offsetsStoreSingle(

--- a/test/promisified/consumer/pause.spec.js
+++ b/test/promisified/consumer/pause.spec.js
@@ -251,6 +251,62 @@ describe('Consumer', () => {
             expect(messagesConsumed).toContainEqual({ topic: 1, message: 3 });
         }, 10000);
 
+        it('resumes from the first unprocessed message when pausing with prefetched batches', async () => {
+            /* Regression test: pause() discards prefetched messages from the
+             * message cache (markStale) and relies on #lastConsumedOffsets to
+             * seek back to the first unconsumed message. The eachBatch
+             * resolveOffset path did not populate that map, so any messages
+             * already prefetched into the cache beyond the current batch were
+             * permanently lost after pause()/resume(). Needs enough messages
+             * that the fetch delivers batches beyond the one being processed
+             * when pause() is called. */
+            const topic = topics[0];
+            const messageCount = 120;
+            const messages = Array.from({ length: messageCount }, (_, i) => ({
+                key: `key-${i}`,
+                value: `value-${i}`,
+                partition: 0,
+            }));
+
+            await consumer.connect();
+            await producer.connect();
+            await producer.send({ topic, messages });
+            await consumer.subscribe({ topic });
+
+            let batchesProcessed = 0;
+            let pausedOnce = false;
+            const consumedValues = new Set();
+            consumer.run({
+                eachBatchAutoResolve: false,
+                eachBatch: async event => {
+                    const { batch, resolveOffset } = event;
+                    batchesProcessed++;
+                    for (const message of batch.messages) {
+                        consumedValues.add(String(message.value));
+                        /* Resolve everything: the post-batch repair seek must
+                         * not fire; recovery of the discarded prefetched
+                         * messages depends solely on the pause() seek. */
+                        resolveOffset(message.offset);
+                    }
+                    /* Pause once the cache is warm so later batches are
+                     * already prefetched and get discarded by pause(). */
+                    if (!pausedOnce && batchesProcessed >= 4) {
+                        pausedOnce = true;
+                        const resume = event.pause();
+                        setTimeout(resume, 500);
+                    }
+                },
+            });
+
+            await waitForConsumerToJoinGroup(consumer);
+            /* Bounded wait: without the fix consumption wedges permanently,
+             * and an unbounded waitFor would hang the suite (the wedged
+             * consumer also hangs disconnect()). */
+            const deadline = Date.now() + 20000;
+            await waitFor(() => consumedValues.size >= messageCount || Date.now() > deadline, () => null, { delay: 100 });
+            expect(consumedValues.size).toEqual(messageCount);
+        }, 30000);
+
         it('does not fetch messages for the paused topic', async () => {
             await consumer.connect();
             await producer.connect();


### PR DESCRIPTION
Fixes #517.

## Problem

For `eachBatch` consumers, `consumer.pause()` permanently skips every message prefetched into the message cache beyond the batch being processed. `#pauseInternal` discards the cache (`markStale`) and repairs the fetch position by seeking to `#lastConsumedOffsets + 1` — but `#eachBatchPayload_resolveOffsets` never wrote to that map (despite its doc comment saying it does; only the `eachMessage` path did). With the map empty, no repair seek is issued and the discarded messages are lost: consumption appears wedged after `resume()`, and the skipped offsets are eventually committed.

Broker-independent (reproduced on AK 3.9 ZK/KRaft and 4.0 KRaft). Requires a warm cache — batches prefetched beyond the current one — which is why the existing 4-message pause specs never caught it (their pause target is inside the current payload, where the post-batch repair seek in `#batchProcessor` masks the loss).

## Fix

Update `#lastConsumedOffsets` in `#eachBatchPayload_resolveOffsets`, mirroring `#messageProcessor`.

## Testing

- New regression test in `pause.spec.js`: produces 120 messages, resolves every message of each batch (so the post-batch repair seek cannot mask the bug), pauses via the callback's `pause()` once the cache is warm, resumes 500ms later, and asserts complete consumption. Fails (wedges at the pause point) without the fix; passes with it.
- Full `test/promisified/consumer/pause.spec.js` suite: 16/16 pass with the fix (AK 4.0 broker; also verified against 3.9 with the standalone repro from the issue).
- The wait in the new test is deadline-bounded because without the fix the wedged consumer also hangs `disconnect()`, which would otherwise hang the suite in `afterEach`.

Found while migrating a large kafkajs deployment (~40 services) to this client; happy to adjust style/placement as needed.