### PR TITLE
[DOCS-39462]-Use Schema Registry in the README Getting Started example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,21 @@ Yarn and pnpm support is experimental.
 
 Below is a simple produce example using the promisified API.
 
+Production applications should serialize with Schema Registry. Producing plain string
+values leads to data-quality issues, broken consumers, and ungovernable data. This
+example uses the companion [@confluentinc/schemaregistry](https://www.npmjs.com/package/@confluentinc/schemaregistry)
+package, which is installed separately.
+
 ```javascript
 const { Kafka } = require('@confluentinc/kafka-javascript').KafkaJS;
+const { SchemaRegistryClient, SerdeType, JsonSerializer } = require('@confluentinc/schemaregistry');
 
 async function producerStart() {
+    // autoRegisterSchemas registers the schema on first produce. Use
+    // useLatestVersion instead when the schema is already registered.
+    const registry = new SchemaRegistryClient({ baseURLs: ['http://localhost:8081'] });
+    const serializer = new JsonSerializer(registry, SerdeType.VALUE, { autoRegisterSchemas: true });
+
     const producer = new Kafka().producer({
         'bootstrap.servers': '<fill>',
         'security.protocol': 'SASL_SSL',
@@ -75,16 +86,13 @@ async function producerStart() {
     await producer.connect();
     console.log("Connected successfully");
 
-    const res = []
-    for (let i = 0; i < 50; i++) {
-        res.push(producer.send({
-            topic: 'test-topic',
-            messages: [
-                { value: 'v', partition: 0, key: 'x' },
-            ]
-        }));
-    }
-    await Promise.all(res);
+    const user = { name: 'Confluent', favoriteNumber: 42 };
+    await producer.send({
+        topic: 'test-topic',
+        messages: [
+            { value: await serializer.serialize('test-topic', user), key: 'user1' },
+        ],
+    });
 
     await producer.disconnect();
     console.log("Disconnected successfully");
@@ -92,6 +100,8 @@ async function producerStart() {
 
 producerStart();
 ```
+
+For an Avro example that also consumes and deserializes, see [sr.js](examples/kafkajs/sr.js).
 
 There are two variants of the API offered by this library. A promisified API and a callback-based API.
 


### PR DESCRIPTION
## Summary

- Change the README's Getting Started example from sending a raw `{ value: 'v' }` loop to serializing through `JsonSerializer` from `@confluentinc/schemaregistry`.
- Use `new JsonSerializer(registry, SerdeType.VALUE, { autoRegisterSchemas: true })` so the schema is registered on first produce.
- Add a trailer linking `examples/kafkajs/sr.js`.

Addresses DOCS-39462: the first example a developer copies sets the default. Producing raw bytes leads to data-quality issues, broken consumers, and ungovernable data, so the README's first-run example should use Schema Registry. This is one of five coordinated PRs across librdkafka, confluent-kafka-python, confluent-kafka-go, confluent-kafka-dotnet, and confluent-kafka-javascript.

## Verification

- Example verified by an SME against a local broker and Schema Registry. An earlier draft used `{ useLatestVersion: true }`, which looks up a pre-existing schema and 404s on first produce; `{ autoRegisterSchemas: true }` is the correct option and is confirmed in `schemaregistry/serde/serde.ts`.
- Snippet extracted from the rendered README and checked with `node --check`.
