### PR TITLE
Update transitive dependencies in package-lock.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 
 ## Fixes
 1. Preserve HTTP status on Schema Registry error responses (#519)
-2. Upgrade transitive dependencies in package-lock.json for security patches (#)
+2. Upgrade transitive dependencies in package-lock.json for security patches (#525)
+3. Store a message as last consumed offset only after processing `eachMessage`, at the same time when it's stored for committing (#525)
+4. Avoid a message duplicate when seeking back for reprocessing a message or batch (#525)
 
 
 # confluent-kafka-javascript 1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 ## Fixes
 1. Preserve HTTP status on Schema Registry error responses (#519)
 2. Upgrade transitive dependencies in package-lock.json for security patches (#525)
-3. Store a message as last consumed offset only after processing `eachMessage`, at the same time when it's stored for committing (#525)
-4. Avoid a message duplicate when seeking back for reprocessing a message or batch (#525)
+3. Store a message as last consumed offset only after processing `eachMessage` or resolving offsets in `eachBatch`, at the same time when it's stored for being committed (#525)
+4. Avoid a single message duplicate when seeking back for reprocessing a message or batch (#525)
 5. Fix a crash when an admin operation fails before its result event is received, caused by the event being uninitialized in the admin workers (#525)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# confluent-kafka-javascript 1.x.x
+# confluent-kafka-javascript 1.10.1 (not released)
 
 ## Enhancements
 1. Support generating a JSON Schema title from a JSON payload (#505)
@@ -7,6 +7,7 @@
 
 ## Fixes
 1. Preserve HTTP status on Schema Registry error responses (#519)
+2. Upgrade transitive dependencies in package-lock.json for security patches (#)
 
 
 # confluent-kafka-javascript 1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 2. Upgrade transitive dependencies in package-lock.json for security patches (#525)
 3. Store a message as last consumed offset only after processing `eachMessage`, at the same time when it's stored for committing (#525)
 4. Avoid a message duplicate when seeking back for reprocessing a message or batch (#525)
+5. Fix a crash when an admin operation fails before its result event is received, caused by the event being uninitialized in the admin workers (#525)
 
 
 # confluent-kafka-javascript 1.10.0

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -343,7 +343,7 @@ class Consumer {
         {
           topic: topicPartition.topic,
           partition: topicPartition.partition,
-          offset: lastConsumedOffsets.offset,
+          offset: Number(lastConsumedOffsets.offset) + 1,
           leaderEpoch: lastConsumedOffsets.leaderEpoch,
         }
       ];
@@ -879,6 +879,12 @@ class Consumer {
         partition,
         offset + 1,
         leaderEpoch);
+      this.#lastConsumedOffsets.set(partitionKey({ topic, partition }), {
+        topic,
+        partition,
+        offset,
+        leaderEpoch,
+      });
     } catch (e) {
       /* Not much we can do, except log the error. */
       this.#logger.error(`Consumer encountered error while storing offset. Error details: ${e}:${e.stack}`, this.#createConsumerBindingMessageMetadata());
@@ -1336,7 +1342,6 @@ class Consumer {
     const payload = this.#createPayload(m, worker);
 
     try {
-      this.#lastConsumedOffsets.set(key, m);
       await config.eachMessage(payload);
       eachMessageProcessed = true;
     } catch (e) {
@@ -1369,6 +1374,7 @@ class Consumer {
     if (eachMessageProcessed) {
       try {
         this.#internalClient._offsetsStoreSingle(m.topic, m.partition, Number(m.offset) + 1, m.leaderEpoch);
+        this.#lastConsumedOffsets.set(key, m);
       } catch (e) {
         /* Not much we can do, except log the error. */
         this.#logger.error(`Consumer encountered error while storing offset. Error details: ${JSON.stringify(e)}`, this.#createConsumerBindingMessageMetadata());
@@ -1468,7 +1474,10 @@ class Consumer {
         this.#lastConsumedOffsets.set(ppc.key, {
           topic: firstMessage.topic,
           partition: firstMessage.partition,
-          offset: firstMessage.offset - 1,
+          /* The preceding message hasn't been consumed by us, so its leader
+           * epoch is unknown and could differ from this message's: use -1. */
+          offset: Number(firstMessage.offset) - 1,
+          leaderEpoch: -1,
         });
     }
 

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -343,7 +343,7 @@ class Consumer {
         {
           topic: topicPartition.topic,
           partition: topicPartition.partition,
-          offset: Number(lastConsumedOffsets.offset) + 1,
+          offset: lastConsumedOffsets.offset + 1,
           leaderEpoch: lastConsumedOffsets.leaderEpoch,
         }
       ];
@@ -1373,7 +1373,7 @@ class Consumer {
     /* Store the offsets we need to store, or at least record them for cache invalidation reasons. */
     if (eachMessageProcessed) {
       try {
-        this.#internalClient._offsetsStoreSingle(m.topic, m.partition, Number(m.offset) + 1, m.leaderEpoch);
+        this.#internalClient._offsetsStoreSingle(m.topic, m.partition, m.offset + 1, m.leaderEpoch);
         this.#lastConsumedOffsets.set(key, m);
       } catch (e) {
         /* Not much we can do, except log the error. */
@@ -1476,7 +1476,7 @@ class Consumer {
           partition: firstMessage.partition,
           /* The preceding message hasn't been consumed by us, so its leader
            * epoch is unknown and could differ from this message's: use -1. */
-          offset: Number(firstMessage.offset) - 1,
+          offset: firstMessage.offset - 1,
           leaderEpoch: -1,
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2092,9 +2092,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3382,16 +3382,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3689,13 +3689,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -3948,9 +3948,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4098,9 +4098,9 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5114,16 +5114,16 @@
       }
     },
     "node_modules/eslint-plugin-tsdoc/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint-plugin-tsdoc/node_modules/eslint-visitor-keys": {
@@ -5357,9 +5357,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -5934,9 +5934,9 @@
       }
     },
     "node_modules/google-gax/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6303,9 +6303,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7287,9 +7287,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -7544,9 +7544,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {
@@ -8085,9 +8085,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9067,9 +9067,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9880,9 +9880,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/src/workers.h
+++ b/src/workers.h
@@ -548,7 +548,7 @@ class AdminClientListGroups : public ErrorAwareWorker {
   const bool m_is_match_types_set;
   std::vector<rd_kafka_consumer_group_type_t> m_match_types;
   const int m_timeout_ms;
-  rd_kafka_event_t *m_event_response;
+  rd_kafka_event_t *m_event_response = NULL;
 };
 
 /**
@@ -569,7 +569,7 @@ class AdminClientDescribeGroups : public ErrorAwareWorker {
   std::vector<std::string> m_groups;
   const bool m_include_authorized_operations;
   const int m_timeout_ms;
-  rd_kafka_event_t *m_event_response;
+  rd_kafka_event_t *m_event_response = NULL;
 };
 
 /**
@@ -590,7 +590,7 @@ class AdminClientDeleteGroups : public ErrorAwareWorker {
   rd_kafka_DeleteGroup_t **m_group_list;
   size_t m_group_cnt;
   const int m_timeout_ms;
-  rd_kafka_event_t *m_event_response;
+  rd_kafka_event_t *m_event_response = NULL;
 };
 
 /**
@@ -613,7 +613,7 @@ class AdminClientListConsumerGroupOffsets : public ErrorAwareWorker {
   size_t m_req_cnt;
   const bool m_require_stable_offsets;
   const int m_timeout_ms;
-  rd_kafka_event_t *m_event_response;
+  rd_kafka_event_t *m_event_response = NULL;
 };
 
 /**
@@ -636,7 +636,7 @@ class AdminClientDeleteRecords : public ErrorAwareWorker {
   size_t m_del_records_cnt;
   const int m_operation_timeout_ms;
   const int m_timeout_ms;
-  rd_kafka_event_t *m_event_response;
+  rd_kafka_event_t *m_event_response = NULL;
 };
 
 /**
@@ -658,7 +658,7 @@ class AdminClientDescribeTopics : public ErrorAwareWorker {
   rd_kafka_TopicCollection_t *m_topics;
   const bool m_include_authorized_operations;
   const int m_timeout_ms;
-  rd_kafka_event_t *m_event_response;
+  rd_kafka_event_t *m_event_response = NULL;
 };
 
 /**
@@ -680,7 +680,7 @@ class AdminClientListOffsets : public ErrorAwareWorker {
   rd_kafka_topic_partition_list_t *m_partitions;
   const int m_timeout_ms;
   const rd_kafka_IsolationLevel_t m_isolation_level;
-  rd_kafka_event_t *m_event_response;
+  rd_kafka_event_t *m_event_response = NULL;
 };
 
 }  // namespace Workers

--- a/test/promisified/admin/fetch_offsets.spec.js
+++ b/test/promisified/admin/fetch_offsets.spec.js
@@ -7,6 +7,7 @@ const {
   createProducer,
   createConsumer,
   waitForMessages,
+  waitFor,
   createAdmin,
 } = require("../testhelpers");
 
@@ -260,6 +261,9 @@ describe("fetchOffset function", () => {
     await producer.send({ topic: topicName2, messages });
 
     let messagesConsumed = []; // Define messagesConsumed
+    // One commit per partition: 2 topics with 2 partitions each.
+    const expectedCommits = 4;
+    let commits = 0;
 
     await consumer.run({
       eachMessage: async ({ topic, partition, message }) => {
@@ -275,11 +279,16 @@ describe("fetchOffset function", () => {
               offset: (parseInt(message.offset, 10) + 1).toString(),
             },
           ]);
+          commits++;
         }
       },
     });
 
     await waitForMessages(messagesConsumed, { number: 20 });
+    /* A message is pushed to messagesConsumed before its offset is committed,
+     * so all 20 messages having arrived does not mean every commit has landed.
+     * fetchOffsets would then miss the partitions still being committed. */
+    await waitFor(() => commits === expectedCommits, () => null, { delay: 100 });
 
     // Fetch offsets with multiple topics each with more than 1 partition
     const offsets = await admin.fetchOffsets({

--- a/test/promisified/consumer/consumeMessages.spec.js
+++ b/test/promisified/consumer/consumeMessages.spec.js
@@ -734,7 +734,7 @@ describe.each(cases)('Consumer - partitionsConsumedConcurrently = %s -', (partit
 
         let errors = false;
         let receivedMessages = 0;
-        let firstLongBatchProcessing;
+        let staleBatchIndex, staleBatchSize;
         consumer.run({
             partitionsConsumedConcurrently,
             eachBatchAutoResolve: true,
@@ -742,23 +742,25 @@ describe.each(cases)('Consumer - partitionsConsumedConcurrently = %s -', (partit
                 receivedMessages++;
 
                 try {
-                    if (!firstLongBatchProcessing && event.batch.messages.length >= 32) {
+                    if (!staleBatchIndex && event.batch.messages.length >= 32) {
                         expect(event.isStale()).toEqual(false);
-                        await sleep(6000);
-                        /* 6s 'processing'
-                         * cache clearance starts at 7000 */
-                        expect(event.isStale()).toEqual(false);
-                        firstLongBatchProcessing = receivedMessages;
-                    }
-                    if (firstLongBatchProcessing && receivedMessages === firstLongBatchProcessing + 1) {
-                        expect(event.isStale()).toEqual(false);
-                        await sleep(10000);
-                        /* 10s 'processing'
-                         * 16s in total exceeds max poll interval.
-                         * in this last batch after clearance.
-                         * Batch is marked stale
-                         * and partitions are lost */
+                        /* 16s 'processing' in a single batch exceeds the effective
+                         * max poll interval (2 * max.poll.interval.ms = 14s), which
+                         * is measured from the last fetch. Spreading the wait over
+                         * two consecutive batches instead only exceeds it when the
+                         * second batch is served from a cache filled by the same
+                         * fetch, and the cache is sized dynamically
+                         * (js.consumer.max.cache.size.per.worker.ms), so a fetch
+                         * in between would reset the deadline and the batch would
+                         * never go stale.
+                         * Batch is marked stale and partitions are lost. */
+                        await sleep(16000);
                         expect(event.isStale()).toEqual(true);
+                        /* The batch is left unresolved because it went stale, so
+                         * exactly these messages are re-consumed once the
+                         * partitions are regained. */
+                        staleBatchIndex = receivedMessages;
+                        staleBatchSize = event.batch.messages.length;
                     }
                 } catch (e) {
                     console.error(e);
@@ -777,16 +779,19 @@ describe.each(cases)('Consumer - partitionsConsumedConcurrently = %s -', (partit
             });
 
         await producer.send({ topic: topicName, messages });
-        /* 32 message are re-consumed after not being resolved
-         * because of the stale batch */
-        await waitForMessages(messagesConsumed, { number: totalMessages + 32, delay: 100 });
-        expect(messagesConsumed.length).toEqual(totalMessages + 32);
+        /* The messages of the stale batch are re-consumed after not being
+         * resolved. Its size is whatever was fetched rather than a fixed 32,
+         * as batches are filled with up to js.consumer.max.batch.size
+         * messages, depending on what is available. */
+        await waitFor(() => staleBatchSize !== undefined, () => null, { delay: 100 });
+        await waitForMessages(messagesConsumed, { number: totalMessages + staleBatchSize, delay: 100 });
+        expect(messagesConsumed.length).toEqual(totalMessages + staleBatchSize);
 
         /* Triggers revocation */
         await consumer.disconnect();
 
-        expect(firstLongBatchProcessing).toBeDefined();
-        expect(receivedMessages).toBeGreaterThan(firstLongBatchProcessing);
+        expect(staleBatchIndex).toBeDefined();
+        expect(receivedMessages).toBeGreaterThan(staleBatchIndex);
 
         /* First assignment + assignment after partitions lost */
         expect(assigns).toEqual(2);

--- a/test/promisified/consumer/consumeMessages.spec.js
+++ b/test/promisified/consumer/consumeMessages.spec.js
@@ -757,7 +757,7 @@ describe.each(cases)('Consumer - partitionsConsumedConcurrently = %s -', (partit
                         await sleep(16000);
                         expect(event.isStale()).toEqual(true);
                         /* The batch is left unresolved because it went stale, so
-                         * exactly these messages are re-consumed once the
+                         * at least these messages are re-consumed once the
                          * partitions are regained. */
                         staleBatchIndex = receivedMessages;
                         staleBatchSize = event.batch.messages.length;
@@ -779,16 +779,26 @@ describe.each(cases)('Consumer - partitionsConsumedConcurrently = %s -', (partit
             });
 
         await producer.send({ topic: topicName, messages });
-        /* The messages of the stale batch are re-consumed after not being
-         * resolved. Its size is whatever was fetched rather than a fixed 32,
-         * as batches are filled with up to js.consumer.max.batch.size
-         * messages, depending on what is available. */
+
+        /* The unresolved stale batch is re-consumed once the partitions are
+         * regained, so every message is delivered and at least the messages of
+         * that batch are delivered twice. The exact number of duplicates is not
+         * asserted: consumption resumes from the last committed offset, and how
+         * much had been committed by the time the partitions were lost also
+         * decides whether batches preceding the stale one are replayed. */
+        const distinctOffsets = () => new Set(messagesConsumed.map(m => Number(m.offset)));
         await waitFor(() => staleBatchSize !== undefined, () => null, { delay: 100 });
-        await waitForMessages(messagesConsumed, { number: totalMessages + staleBatchSize, delay: 100 });
-        expect(messagesConsumed.length).toEqual(totalMessages + staleBatchSize);
+        await waitFor(() => distinctOffsets().size === totalMessages &&
+            messagesConsumed.length - totalMessages >= staleBatchSize,
+        () => null, { delay: 100 });
 
         /* Triggers revocation */
         await consumer.disconnect();
+
+        /* No message is lost, */
+        expect(distinctOffsets().size).toEqual(totalMessages);
+        /* and the stale batch is reprocessed. */
+        expect(messagesConsumed.length - totalMessages).toBeGreaterThanOrEqual(staleBatchSize);
 
         expect(staleBatchIndex).toBeDefined();
         expect(receivedMessages).toBeGreaterThan(staleBatchIndex);

--- a/test/promisified/consumer/consumerCacheTests.spec.js
+++ b/test/promisified/consumer/consumerCacheTests.spec.js
@@ -232,10 +232,6 @@ describe.each(cases)('Consumer message cache - isAutoCommit = %s - partitionsCon
          * non-message events like rebalances, etc. Internally, this is to make sure that
          * we call poll() at least once within max.poll.interval.ms even if the cache is
          * still full. This depends on us expiring the cache on time. */
-
-        /* FIXME: this test can be flaky when using KIP-848 protocol and
-         * auto-commit. To check if there's something to fix about that case.
-         */
         const impatientConsumer = createConsumer({
             groupId,
             maxWaitTimeInMs: 100,


### PR DESCRIPTION
## Summary
- Bumps transitive dependencies in `package-lock.json` to their latest patch/minor versions, including `js-yaml`, `brace-expansion`, `axios`, `tar`, `protobufjs`, `fast-uri`, `ip-address`, and `linkify-it`.
- No `package.json` version ranges changed; this only refreshes resolved/integrity entries within existing semver ranges.
- CHANGELOG.md updated accordingly.

## Test plan
- [x] `npm ci` installs cleanly with the updated lockfile
- [x] Existing test suite passes