### PR TITLE
Add describeCluster to the Admin API

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -690,6 +690,49 @@ AdminClient.prototype.describeTopics = function (topics, options, cb) {
 };
 
 /**
+ * Describe the cluster.
+ *
+ * @param {object} options
+ * @param {number?} options.timeout - The request timeout in milliseconds.
+ *                                    May be unset (default: 5000).
+ * @param {boolean?} options.includeAuthorizedOperations - If true, include operations allowed on the cluster by the calling client.
+ *                                                         (default: false).
+ * @param {function} cb - The callback to be executed when finished.
+ *
+ * @example
+ * // Valid ways to call this function:
+ * describeCluster(cb)
+ * describeCluster(options, cb)
+ */
+AdminClient.prototype.describeCluster = function (options, cb) {
+  if (!this._isConnected) {
+    throw new Error('Client is disconnected');
+  }
+
+  if (typeof options === 'function') {
+    cb = options;
+    options = {};
+  }
+
+  if (!options) {
+    options = {};
+  }
+
+  this._client.describeCluster(options, function (err, description) {
+    if (err) {
+      if (cb) {
+        cb(LibrdKafkaError.create(err));
+      }
+      return;
+    }
+
+    if (cb) {
+      cb(null, description);
+    }
+  });
+};
+
+/**
  * List offsets for topic partition(s).
  *
  * @param {Array<{topic: string, partition: number, offset: OffsetSpec}>} partitions - The list of partitions to fetch offsets for.

--- a/lib/kafkajs/_admin.js
+++ b/lib/kafkajs/_admin.js
@@ -779,6 +779,53 @@ class Admin {
   }
 
   /**
+   * Describe the cluster.
+   *
+   * @param {object?} options
+   * @param {number?} options.timeout - The request timeout in milliseconds.
+   *                                    May be unset (default: 5000)
+   * @param {boolean?} options.includeAuthorizedOperations - If true, include operations allowed on the cluster
+   *                                                         by the calling client (default: false).
+   *
+   * @returns {Promise<{clusterId: string | null, controller: number | null,
+   *           brokers: Array<{nodeId: number, host: string, port: number, rack?: string}>,
+   *           authorizedOperations?: Array<KafkaJS.AclOperationTypes>}>}
+   */
+  async describeCluster(options = {}) {
+    if (this.#state !== AdminState.CONNECTED) {
+      throw new error.KafkaJSError("Admin client is not connected.", { code: error.ErrorCodes.ERR__STATE });
+    }
+
+    return new Promise((resolve, reject) => {
+      this.#internalClient.describeCluster(options, (err, description) => {
+        if (err) {
+          reject(createKafkaJsErrorFromLibRdKafkaError(err));
+        } else {
+          const convertedDescription = {
+            clusterId: description.clusterId ?? null,
+            controller: description.controller ? description.controller.id : null,
+            brokers: (description.nodes ?? []).map(node => {
+              const broker = {
+                nodeId: node.id,
+                host: node.host,
+                port: node.port,
+              };
+              if (node.rack !== undefined) {
+                broker.rack = node.rack;
+              }
+              return broker;
+            }),
+          };
+          if (description.authorizedOperations) {
+            convertedDescription.authorizedOperations = description.authorizedOperations;
+          }
+          resolve(convertedDescription);
+        }
+      });
+    });
+  }
+
+  /**
    * List offsets for the specified topic partition(s).
    *
    * @param {string} topic - The topic to fetch offsets for.

--- a/src/admin.cc
+++ b/src/admin.cc
@@ -123,6 +123,7 @@ void AdminClient::Init(v8::Local<v8::Object> exports) {
   Nan::SetPrototypeMethod(tpl, "createPartitions", NodeCreatePartitions);
   Nan::SetPrototypeMethod(tpl, "deleteRecords", NodeDeleteRecords);
   Nan::SetPrototypeMethod(tpl, "describeTopics", NodeDescribeTopics);
+  Nan::SetPrototypeMethod(tpl, "describeCluster", NodeDescribeCluster);
   Nan::SetPrototypeMethod(tpl, "listOffsets", NodeListOffsets);
 
   // Consumer group related operations
@@ -915,6 +916,74 @@ Baton AdminClient::DescribeTopics(rd_kafka_TopicCollection_t *topics,
   }
 }
 
+Baton AdminClient::DescribeCluster(bool include_authorized_operations,
+                                   int timeout_ms,
+                                   rd_kafka_event_t **event_response) {
+  if (!IsConnected()) {
+    return Baton(RdKafka::ERR__STATE);
+  }
+
+  {
+    scoped_shared_write_lock lock(m_connection_lock);
+    if (!IsConnected()) {
+      return Baton(RdKafka::ERR__STATE);
+    }
+
+    // Make admin options to establish that we are describing the cluster
+    rd_kafka_AdminOptions_t *options = rd_kafka_AdminOptions_new(
+        m_client->c_ptr(), RD_KAFKA_ADMIN_OP_DESCRIBECLUSTER);
+
+    if (include_authorized_operations) {
+      rd_kafka_error_t *error =
+          rd_kafka_AdminOptions_set_include_authorized_operations(
+              options, include_authorized_operations);
+      if (error) {
+        return Baton::BatonFromErrorAndDestroy(error);
+      }
+    }
+
+    char errstr[512];
+    rd_kafka_resp_err_t err = rd_kafka_AdminOptions_set_request_timeout(
+        options, timeout_ms, errstr, sizeof(errstr));
+    if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {
+      return Baton(static_cast<RdKafka::ErrorCode>(err), errstr);
+    }
+
+    // Create queue just for this operation.
+    rd_kafka_queue_t *rkqu = rd_kafka_queue_new(m_client->c_ptr());
+
+    rd_kafka_DescribeCluster(m_client->c_ptr(), options, rkqu);
+
+    // Poll for an event by type in that queue
+    // DON'T destroy the event. It is the out parameter, and ownership is
+    // the caller's.
+    *event_response =
+        PollForEvent(rkqu, RD_KAFKA_EVENT_DESCRIBECLUSTER_RESULT, timeout_ms);
+
+    // Destroy the queue since we are done with it.
+    rd_kafka_queue_destroy(rkqu);
+
+    // Destroy the options we just made because we polled already
+    rd_kafka_AdminOptions_destroy(options);
+
+    // If we got no response from that operation, this is a failure
+    // likely due to time out
+    if (*event_response == NULL) {
+      return Baton(RdKafka::ERR__TIMED_OUT);
+    }
+
+    // Now we can get the error code from the event
+    if (rd_kafka_event_error(*event_response)) {
+      // If we had a special error code, get out of here with it
+      const rd_kafka_resp_err_t errcode = rd_kafka_event_error(*event_response);
+      return Baton(static_cast<RdKafka::ErrorCode>(errcode));
+    }
+
+    // At this point, event_response contains the result, which needs
+    // to be parsed/converted by the caller.
+    return Baton(RdKafka::ERR_NO_ERROR);
+  }
+}
 
 Baton AdminClient::ListOffsets(rd_kafka_topic_partition_list_t *partitions,
                                int timeout_ms,
@@ -1547,6 +1616,35 @@ NAN_METHOD(AdminClient::NodeDescribeTopics) {
   Nan::AsyncQueueWorker(new Workers::AdminClientDescribeTopics(
       callback, client, topic_collection,
       include_authorised_operations, timeout_ms));
+}
+
+/**
+ * Describe Cluster.
+ */
+NAN_METHOD(AdminClient::NodeDescribeCluster) {
+  Nan::HandleScope scope;
+
+  if (info.Length() < 2 || !info[1]->IsFunction()) {
+    return Nan::ThrowError("Need to specify a callback");
+  }
+
+  if (!info[0]->IsObject()) {
+    return Nan::ThrowError("Must provide options object");
+  }
+
+  v8::Local<v8::Object> options = info[0].As<v8::Object>();
+
+  bool include_authorized_operations =
+      GetParameter<bool>(options, "includeAuthorizedOperations", false);
+
+  int timeout_ms = GetParameter<int64_t>(options, "timeout", 5000);
+
+  v8::Local<v8::Function> cb = info[1].As<v8::Function>();
+  Nan::Callback *callback = new Nan::Callback(cb);
+  AdminClient *client = ObjectWrap::Unwrap<AdminClient>(info.This());
+
+  Nan::AsyncQueueWorker(new Workers::AdminClientDescribeCluster(
+      callback, client, include_authorized_operations, timeout_ms));
 }
 
 

--- a/src/admin.h
+++ b/src/admin.h
@@ -73,6 +73,8 @@ class AdminClient : public Connection {
   Baton DescribeTopics(rd_kafka_TopicCollection_t* topics,
                        bool include_authorized_operations, int timeout_ms,
                        rd_kafka_event_t** event_response);
+  Baton DescribeCluster(bool include_authorized_operations, int timeout_ms,
+                        rd_kafka_event_t** event_response);
   Baton ListOffsets(rd_kafka_topic_partition_list_t* partitions, int timeout_ms,
                     rd_kafka_IsolationLevel_t isolation_level,
                     rd_kafka_event_t** event_response);
@@ -101,6 +103,7 @@ class AdminClient : public Connection {
   static NAN_METHOD(NodeListConsumerGroupOffsets);
   static NAN_METHOD(NodeDeleteRecords);
   static NAN_METHOD(NodeDescribeTopics);
+  static NAN_METHOD(NodeDescribeCluster);
   static NAN_METHOD(NodeListOffsets);
 
   static NAN_METHOD(NodeConnect);

--- a/src/common.cc
+++ b/src/common.cc
@@ -1557,6 +1557,56 @@ v8::Local<v8::Array> FromDescribeTopicsResult(
 }
 
 /**
+ * @brief Converts a rd_kafka_DescribeCluster_result_t* into a v8 object.
+ */
+v8::Local<v8::Object> FromDescribeClusterResult(
+    const rd_kafka_DescribeCluster_result_t* result) {
+  /* Return object type:
+    {
+      clusterId?: string,
+      controller?: Node,
+      nodes: Node[],
+      authorizedOperations?: AclOperationType[]
+    }
+  */
+  v8::Local<v8::Object> returnObject = Nan::New<v8::Object>();
+
+  const char* cluster_id = rd_kafka_DescribeCluster_result_cluster_id(result);
+  if (cluster_id) {
+    Nan::Set(returnObject, Nan::New("clusterId").ToLocalChecked(),
+             Nan::New<v8::String>(cluster_id).ToLocalChecked());
+  }
+
+  const rd_kafka_Node_t* controller =
+      rd_kafka_DescribeCluster_result_controller(result);
+  if (controller) {
+    Nan::Set(returnObject, Nan::New("controller").ToLocalChecked(),
+             Conversion::Util::ToV8Object(controller));
+  }
+
+  size_t node_cnt;
+  const rd_kafka_Node_t** nodes =
+      rd_kafka_DescribeCluster_result_nodes(result, &node_cnt);
+  v8::Local<v8::Array> nodesArray = Nan::New<v8::Array>();
+  for (size_t i = 0; i < node_cnt; i++) {
+    Nan::Set(nodesArray, i, Conversion::Util::ToV8Object(nodes[i]));
+  }
+  Nan::Set(returnObject, Nan::New("nodes").ToLocalChecked(), nodesArray);
+
+  size_t authorized_operations_cnt;
+  const rd_kafka_AclOperation_t* authorized_operations =
+      rd_kafka_DescribeCluster_result_authorized_operations(
+          result, &authorized_operations_cnt);
+  if (authorized_operations) {
+    Nan::Set(returnObject, Nan::New("authorizedOperations").ToLocalChecked(),
+             Conversion::Util::ToV8Array(authorized_operations,
+                                         authorized_operations_cnt));
+  }
+
+  return returnObject;
+}
+
+/**
  * @brief Converts a rd_kafka_ListOffsets_result_t* into a v8 Array.
  */
 v8::Local<v8::Array> FromListOffsetsResult(

--- a/src/common.h
+++ b/src/common.h
@@ -148,6 +148,10 @@ v8::Local<v8::Array> FromDeleteRecordsResult(
 v8::Local<v8::Array> FromDescribeTopicsResult(
     const rd_kafka_DescribeTopics_result_t* result);
 
+// DescribeCluster: Response
+v8::Local<v8::Object> FromDescribeClusterResult(
+    const rd_kafka_DescribeCluster_result_t* result);
+
 // ListOffsets: Response
 v8::Local<v8::Array> FromListOffsetsResult(
     const rd_kafka_ListOffsets_result_t* result);

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -1657,8 +1657,57 @@ void AdminClientDescribeTopics::HandleErrorCallback() {
 }
 
 /**
+ * @brief Describe Cluster in an asynchronous worker
+ *
+ * This callback will describe the cluster.
+ */
+AdminClientDescribeCluster::AdminClientDescribeCluster(
+    Nan::Callback* callback, NodeKafka::AdminClient* client,
+    const bool include_authorized_operations,
+    const int& timeout_ms)
+    : ErrorAwareWorker(callback),
+      m_client(client),
+      m_include_authorized_operations(include_authorized_operations),
+      m_timeout_ms(timeout_ms) {}
+
+AdminClientDescribeCluster::~AdminClientDescribeCluster() {
+  if (this->m_event_response) {
+    rd_kafka_event_destroy(this->m_event_response);
+  }
+}
+
+void AdminClientDescribeCluster::Execute() {
+  Baton b = m_client->DescribeCluster(m_include_authorized_operations,
+                                      m_timeout_ms, &m_event_response);
+  if (b.err() != RdKafka::ERR_NO_ERROR) {
+    SetErrorBaton(b);
+  }
+}
+
+void AdminClientDescribeCluster::HandleOKCallback() {
+  Nan::HandleScope scope;
+  const unsigned int argc = 2;
+  v8::Local<v8::Value> argv[argc];
+
+  argv[0] = Nan::Null();
+  argv[1] = Conversion::Admin::FromDescribeClusterResult(
+      rd_kafka_event_DescribeCluster_result(m_event_response));
+
+  callback->Call(argc, argv);
+}
+
+void AdminClientDescribeCluster::HandleErrorCallback() {
+  Nan::HandleScope scope;
+
+  const unsigned int argc = 1;
+  v8::Local<v8::Value> argv[argc] = {GetErrorObject()};
+
+  callback->Call(argc, argv);
+}
+
+/**
  * @brief ListOffsets in an asynchronous worker
- * 
+ *
  * This callback will list requested offsets for the specified topic partitions.
  */
 AdminClientListOffsets::AdminClientListOffsets(

--- a/src/workers.h
+++ b/src/workers.h
@@ -662,6 +662,26 @@ class AdminClientDescribeTopics : public ErrorAwareWorker {
 };
 
 /**
+ * @brief Describe a remote broker cluster.
+ */
+class AdminClientDescribeCluster : public ErrorAwareWorker {
+ public:
+  AdminClientDescribeCluster(Nan::Callback *, NodeKafka::AdminClient *,
+                             const bool, const int &);
+  ~AdminClientDescribeCluster();
+
+  void Execute();
+  void HandleOKCallback();
+  void HandleErrorCallback();
+
+ private:
+  NodeKafka::AdminClient *m_client;
+  const bool m_include_authorized_operations;
+  const int m_timeout_ms;
+  rd_kafka_event_t *m_event_response = NULL;
+};
+
+/**
  * @brief List Offsets on a remote broker cluster.
  */
 class AdminClientListOffsets : public ErrorAwareWorker {

--- a/test/promisified/admin/describe_cluster.spec.js
+++ b/test/promisified/admin/describe_cluster.spec.js
@@ -1,0 +1,76 @@
+jest.setTimeout(30000);
+
+const {
+    createAdmin,
+} = require('../testhelpers');
+const { ErrorCodes } = require('../../../lib').KafkaJS;
+
+describe('Admin > describeCluster', () => {
+    let admin;
+
+    beforeEach(async () => {
+        admin = createAdmin({});
+    });
+
+    afterEach(async () => {
+        admin && (await admin.disconnect());
+    });
+
+    it('should throw an error when not connected', async () => {
+        await expect(admin.describeCluster()).rejects.toHaveProperty(
+            'code',
+            ErrorCodes.ERR__STATE
+        );
+    });
+
+    it('should timeout', async () => {
+        await admin.connect();
+
+        while (true) {
+            try {
+                await admin.describeCluster({ timeout: 0.00001 });
+                jest.fail('Should have thrown an error');
+            } catch (e) {
+                if (e.code === ErrorCodes.ERR__TRANSPORT)
+                    continue;
+                expect(e).toHaveProperty(
+                    'code',
+                    ErrorCodes.ERR__TIMED_OUT
+                );
+                break;
+            }
+        }
+    });
+
+    it('should describe the cluster', async () => {
+        await admin.connect();
+
+        const description = await admin.describeCluster();
+
+        expect(typeof description.clusterId).toBe('string');
+        expect(description.clusterId.length).toBeGreaterThan(0);
+        expect(typeof description.controller).toBe('number');
+        expect(Array.isArray(description.brokers)).toBe(true);
+        expect(description.brokers.length).toBeGreaterThan(0);
+        for (const broker of description.brokers) {
+            expect(typeof broker.nodeId).toBe('number');
+            expect(typeof broker.host).toBe('string');
+            expect(typeof broker.port).toBe('number');
+        }
+        expect(description.brokers.map(broker => broker.nodeId)).toContain(
+            description.controller
+        );
+        expect(description.authorizedOperations).toBeUndefined();
+    });
+
+    it('should include authorized operations when requested', async () => {
+        await admin.connect();
+
+        const description = await admin.describeCluster({
+            includeAuthorizedOperations: true,
+        });
+
+        expect(Array.isArray(description.authorizedOperations)).toBe(true);
+        expect(description.authorizedOperations.length).toBeGreaterThan(0);
+    });
+});

--- a/types/kafkajs.d.ts
+++ b/types/kafkajs.d.ts
@@ -423,6 +423,13 @@ export interface ITopicConfig {
   configEntries?: IResourceConfigEntry[]
 }
 
+export interface DescribeClusterResult {
+  clusterId: string | null
+  controller: number | null
+  brokers: Array<{ nodeId: number, host: string, port: number, rack?: string }>
+  authorizedOperations?: AclOperationTypes[]
+}
+
 export type Admin = {
   connect(): Promise<void>
   disconnect(): Promise<void>
@@ -456,6 +463,10 @@ export type Admin = {
     includeAuthorizedOperations?: boolean,
     timeout?: number
   }): Promise<Array<ITopicMetadata>>
+  describeCluster(options?: {
+    timeout?: number,
+    includeAuthorizedOperations?: boolean
+  }): Promise<DescribeClusterResult>
   fetchTopicOffsets(topic: string,
     options?: {
       timeout?: number,

--- a/types/rdkafka.d.ts
+++ b/types/rdkafka.d.ts
@@ -474,6 +474,13 @@ export type TopicDescription = {
     authorizedOperations?: AclOperationTypes[]
 }
 
+export type ClusterDescription = {
+    clusterId?: string
+    controller?: Node
+    nodes: Node[]
+    authorizedOperations?: AclOperationTypes[]
+}
+
 export class OffsetSpec {
     constructor(timestamp: number);
     static EARLIEST: OffsetSpec;
@@ -539,6 +546,10 @@ export interface IAdminClient {
     describeTopics(topics: string[],
         options?: { includeAuthorizedOperations?: boolean, timeout?: number },
         cb?: (err: LibrdKafkaError, result: TopicDescription[]) => any): void;
+
+    describeCluster(cb?: (err: LibrdKafkaError, result: ClusterDescription) => any): void;
+    describeCluster(options?: { includeAuthorizedOperations?: boolean, timeout?: number },
+        cb?: (err: LibrdKafkaError, result: ClusterDescription) => any): void;
 
     listOffsets(partitions: TopicPartitionOffsetSpec[],
         options?: { timeout?: number, isolationLevel?: IsolationLevel },


### PR DESCRIPTION
What
----
Adds `describeCluster()` to the Admin API, wiring the librdkafka admin operation `rd_kafka_DescribeCluster()` (librdkafka v2.3.0+, bundled v2.15.0) through all layers:

- **C++**: `AdminClient::DescribeCluster` dispatcher (`RD_KAFKA_ADMIN_OP_DESCRIBECLUSTER` + `RD_KAFKA_EVENT_DESCRIBECLUSTER_RESULT`), `AdminClientDescribeCluster` async worker, and `FromDescribeClusterResult` v8 converter — all following the existing `describeTopics`/`describeGroups` precedent.
- **Callback API** (`lib/admin.js`): `describeCluster(options?, cb)` returning `{ clusterId, controller: Node, nodes: Node[], authorizedOperations? }`.
- **Promisified API** (`lib/kafkajs/_admin.js`): `describeCluster(options?)` resolving with the KafkaJS-compatible shape `{ clusterId, controller: number | null, brokers: [{ nodeId, host, port, rack? }], authorizedOperations? }`.
- **Types**: `ClusterDescription` (`types/rdkafka.d.ts`) and `DescribeClusterResult` (`types/kafkajs.d.ts`).

`options` supports `timeout` (default 5000) and `includeAuthorizedOperations` (default false), consistent with `describeTopics`/`describeGroups`.

Why `rd_kafka_DescribeCluster()` rather than `rd_kafka_clusterid()`: the admin operation sends its MetadataRequest with an empty topic list, so it performs a genuine broker round-trip on every call with no per-topic metadata or authorization cost, and its result is never served from the client's local metadata cache. This makes it usable as a cheap connectivity probe against large clusters, and matches the KafkaJS `admin.describeCluster()` semantics.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes — new Admin API method `describeCluster()` (callback + promisified) and new TypeScript types. Purely additive; no changes to existing behavior.
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - `test/promisified/admin/describe_cluster.spec.js` (jest, promisified API): not-connected error, timeout, cluster description shape (clusterId/controller/brokers), and `includeAuthorizedOperations`.

References
----------
JIRA: N/A (external contribution)

Test & Review
------------
All run locally on macOS (arm64), Node v20.19.1, against a single-node KRaft broker (`apache/kafka:3.8.0` in Docker), after a from-source build (`node-gyp configure && node-gyp build`):

- `npx jest test/promisified/admin/` — 13 suites / 48 tests passed (including the 4 new `describe_cluster` tests; no regressions in existing admin suites)
- `make test` (mocha unit) — 78 passing
- `make cpplint` — clean on all touched C++ files
- `eslint lib` — clean
- `npm run test:types` (tsc) — clean

Additional verification that the call is a real round-trip and not cache-served:

1. Broker up → `describeCluster()` succeeds: `{"clusterId":"5L6g3nShT-eMCtK--X86sw","controller":1,"brokers":[{"nodeId":1,"host":"localhost","port":9092}]}`
2. `docker stop` the only broker → `describeCluster({ timeout: 5000 })` fails with `ERR__TIMED_OUT (-185)` (a cache-serving implementation would still succeed here)
3. `docker start` the broker → `describeCluster()` succeeds again

Open questions / Follow-ups
--------------------------
- Happy to add a CHANGELOG.md entry to the unreleased 1.10.1 section once the PR number is assigned, if that's preferred in this PR.
