### PR TITLE
[Typescript] Pass errors to loggers

### DIFF
--- a/lib/kafkajs/_admin.js
+++ b/lib/kafkajs/_admin.js
@@ -205,7 +205,8 @@ class Admin {
       if (!this.#connectionError)
         this.#connectionError = err;
     }
-    this.#logger.error(`Error: ${err.message}`, this.#createAdminBindingMessageMetadata());
+    this.#logger.error(`Error: ${err.message}`,
+      { ...this.#createAdminBindingMessageMetadata(), error: err });
   }
 
   /**

--- a/lib/kafkajs/_consumer.js
+++ b/lib/kafkajs/_consumer.js
@@ -355,7 +355,8 @@ class Consumer {
       await Promise.all(seeks);
     } catch (err) {
       /* TODO: we should cry more about this and render the consumer unusable. */
-      this.#logger.error(`Seek error. This is effectively a fatal error: ${err.stack}`);
+      this.#logger.error('Seek error. This is effectively a fatal error',
+        { error: err });
     }
   }
 
@@ -429,8 +430,9 @@ class Consumer {
         try {
           alternateAssignment = await userSpecifiedRebalanceCb(err, assignment, assignmentFns);
         } catch (e) {
-          this.#logger.error(`Error from user's rebalance callback: ${e.stack}, `+
-                             'continuing with the default rebalance behavior.');
+          this.#logger.error(`Error from user's rebalance callback, ` +
+                             'continuing with the default rebalance behavior.',
+                             { error: e });
         }
 
         if (alternateAssignment) {
@@ -676,7 +678,7 @@ class Consumer {
       this.#rebalanceCallback(err, assignment).catch(e =>
       {
         if (this.#logger)
-          this.#logger.error(`Error from rebalance callback: ${e.stack}`);
+          this.#logger.error('Error from rebalance callback', { error: e });
       });
     };
 
@@ -775,7 +777,8 @@ class Consumer {
       if (!this.#connectionError)
         this.#connectionError = err;
     }
-    this.#logger.error(`Error: ${err.message}`, this.#createConsumerBindingMessageMetadata());
+    this.#logger.error(`Error: ${err.message}`,
+      { ...this.#createConsumerBindingMessageMetadata(), error: err });
   }
 
 
@@ -887,7 +890,8 @@ class Consumer {
       });
     } catch (e) {
       /* Not much we can do, except log the error. */
-      this.#logger.error(`Consumer encountered error while storing offset. Error details: ${e}:${e.stack}`, this.#createConsumerBindingMessageMetadata());
+      this.#logger.error('Consumer encountered error while storing offset',
+        { ...this.#createConsumerBindingMessageMetadata(), error: e });
     }
   }
 
@@ -924,7 +928,8 @@ class Consumer {
       watermarkOffsets = this.#internalClient.getWatermarkOffsets(topic, partition);
     } catch (e) {
       /* Only warn. The batch as a whole remains valid but for the fact that the highwatermark won't be there. */
-      this.#logger.warn(`Could not get watermark offsets for batch: ${e}`, this.#createConsumerBindingMessageMetadata());
+      this.#logger.warn('Could not get watermark offsets for batch',
+        { ...this.#createConsumerBindingMessageMetadata(), error: e });
     }
 
     /* Keep default values if it's not a real offset (OFFSET_INVALID: -1001). */
@@ -1356,8 +1361,9 @@ class Consumer {
        * TODO: log error only if error type is not KafkaJSError and if no pause() has been called, else log debug.
        */
       this.#logger.error(
-        `Consumer encountered error while processing message. Error details: ${e}: ${e.stack}. The same message may be reprocessed.`,
-        this.#createConsumerBindingMessageMetadata());
+        'Consumer encountered error while processing message. ' +
+        'The same message may be reprocessed.',
+        { ...this.#createConsumerBindingMessageMetadata(), error: e });
     }
 
     /* If the message is unprocessed, due to an error, or because the user has not resolved it, we seek back. */
@@ -1377,7 +1383,8 @@ class Consumer {
         this.#lastConsumedOffsets.set(key, m);
       } catch (e) {
         /* Not much we can do, except log the error. */
-        this.#logger.error(`Consumer encountered error while storing offset. Error details: ${JSON.stringify(e)}`, this.#createConsumerBindingMessageMetadata());
+        this.#logger.error('Consumer encountered error while storing offset',
+          { ...this.#createConsumerBindingMessageMetadata(), error: e });
       }
     }
 
@@ -1437,8 +1444,9 @@ class Consumer {
        * TODO: log error only if error type is not KafkaJSError and if no pause() has been called, else log debug.
        */
       this.#logger.error(
-        `Consumer encountered error while processing message. Error details: ${e}: ${e.stack}. The same message may be reprocessed.`,
-        this.#createConsumerBindingMessageMetadata());
+        'Consumer encountered error while processing message. ' +
+        'The same message may be reprocessed.',
+        { ...this.#createConsumerBindingMessageMetadata(), error: e });
 
       /* The value of eachBatchAutoResolve is not important. The only place where a message is marked processed
        * despite an error is if the user says so, and the user can use resolveOffset for both the possible
@@ -1502,8 +1510,8 @@ class Consumer {
       this.#notifyNonEmpty();
     };
     nonEmptyAction().catch((e) => {
-      this.#logger.error(`Error in queueNonEmptyCb: ${e}`,
-        this.#createConsumerBindingMessageMetadata());
+      this.#logger.error('Error in queueNonEmptyCb',
+        { ...this.#createConsumerBindingMessageMetadata(), error: e });
     });
   }
   /**
@@ -1542,7 +1550,9 @@ class Consumer {
         /* Since this error cannot be exposed to the user in the current situation, just log and retry.
           * This is due to restartOnFailure being set to always true. */
         if (this.#logger)
-          this.#logger.error(`Consumer encountered error while consuming. Retrying. Error details: ${e} : ${e.stack}`, this.#createConsumerBindingMessageMetadata());
+          this.#logger.error(
+            'Consumer encountered error while consuming. Retrying.',
+            { ...this.#createConsumerBindingMessageMetadata(), error: e });
       }
     }
 
@@ -1671,7 +1681,8 @@ class Consumer {
                 this.#worker(config, perMessageProcessor.bind(this), fetcher.bind(this))
                   .catch(e => {
                     if (this.#logger)
-                      this.#logger.error(`Worker ${i} encountered an error: ${e}:${e.stack}`);
+                      this.#logger.error(`Worker ${i} encountered an error`,
+                        { error: e });
                   }));
 
           /* Best we can do is log errors on worker issues - handled by the catch block above. */
@@ -1833,7 +1844,9 @@ class Consumer {
       this.#internalClient.seek(topicPartitionOffset, 1000,
         (err) => {
           if (err)
-            this.#logger.error(`Error while calling seek from within seekInternal: ${err}`, this.#createConsumerBindingMessageMetadata());
+            this.#logger.error(
+              'Error while calling seek from within seekInternal',
+              { ...this.#createConsumerBindingMessageMetadata(), error: err });
           librdkafkaSeekPromise.resolve();
         });
       librdkafkaSeekPromises.push(librdkafkaSeekPromise);

--- a/lib/kafkajs/_producer.js
+++ b/lib/kafkajs/_producer.js
@@ -376,7 +376,8 @@ class Producer {
       if (!this.#connectionError)
         this.#connectionError = err;
     }
-    this.#logger.error(`Error: ${err.message}`, this.#createProducerBindingMessageMetadata());
+    this.#logger.error(`Error: ${err.message}`,
+      { ...this.#createProducerBindingMessageMetadata(), error: err });
   }
 
   /**

--- a/test/promisified/unit/logger.spec.js
+++ b/test/promisified/unit/logger.spec.js
@@ -71,14 +71,19 @@ function expectStringFirstArg(mockFn, err) {
   expect(mockFn).toHaveBeenCalled();
   const [firstArg, secondArg] = mockFn.mock.calls[mockFn.mock.calls.length - 1];
   expect(firstArg).toEqual(`Error: ${err.message}`);
+  /* The stack is forwarded as the error object rather than being
+   * interpolated into the message. */
+  expect(firstArg).not.toContain(err.stack);
   expect(secondArg).toEqual(expect.objectContaining({
     fac: 'BINDING',
     name: expect.any(String),
     timestamp: expect.any(Number),
+    error: err,
   }));
 }
 
-describe('user-supplied logger receives a string as the first arg on error callbacks', () => {
+describe('user-supplied logger receives a string as the first arg and the ' +
+         'error object in the extras on error callbacks', () => {
   beforeEach(() => {
     RdKafkaMock.__captured.producer = null;
     RdKafkaMock.__captured.consumer = null;


### PR DESCRIPTION
Pass `error` to loggers in the existing `extras` object. Currently, custom loggers do not get passed any underlying error.

Fixes #334

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Pass `error` to loggers in the existing `extras` object. Currently, custom loggers do not get passed any underlying error. That makes it impossible for custom loggers to include things like `error.code`, `error.cause`, etc. 

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?

References
----------
#334
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

I have been running this patch in production.

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
